### PR TITLE
Add DAG for sequential stg_region dbt runs

### DIFF
--- a/dags/region_dags/stg_region.py
+++ b/dags/region_dags/stg_region.py
@@ -1,0 +1,34 @@
+"""Airflow DAG to run dbt models in stg_region folder sequentially."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+from airflow.utils.helpers import chain
+
+DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
+STG_REGION_DIR = DBT_PROJECT_DIR / "stg_region"
+MODEL_NAMES = sorted(p.stem for p in STG_REGION_DIR.glob("*.sql"))
+
+def make_dbt_task(model_name: str) -> BashOperator:
+    """Create a BashOperator to run a dbt model."""
+    return BashOperator(
+        task_id=f"dbt_run_{model_name}",
+        bash_command=(
+            f"cd {DBT_PROJECT_DIR} && "
+            f"dbt run --models {model_name}"
+        ),
+    )
+
+with DAG(
+    dag_id="stg_region",
+    schedule_interval="@daily",
+    start_date=days_ago(1),
+    catchup=False,
+    tags=["region", "staging"],
+) as dag:
+    tasks = [make_dbt_task(name) for name in MODEL_NAMES]
+    if tasks:
+        chain(*tasks)


### PR DESCRIPTION
## Summary
- orchestrate dbt models located in stg_region using an Airflow DAG
- ensure models execute in increasing order via dynamic task chaining

## Testing
- `python -m py_compile dags/region_dags/stg_region.py`


------
https://chatgpt.com/codex/tasks/task_e_688f50b577548330af730b6f4bbe9329