### PR TITLE
feat: add base event generator with seeded randomness

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
 
 ## 📦 Ingestion Layer (Mock Producers)
 
-* [ ] Implement base generator class with reproducible seeded randomness
+* [x] Implement base generator class with reproducible seeded randomness
 * [ ] For each warehouse (`north`, `south`, `east`, `west`):
 
   * [ ] `produce_orders_<region>.py`

--- a/ingestion/rabbitmq_producers/base_generator.py
+++ b/ingestion/rabbitmq_producers/base_generator.py
@@ -1,0 +1,38 @@
+"""Common utilities for RabbitMQ event generators.
+
+This module defines :class:`BaseGenerator` which provides a reproducible
+random number generator.  Producers can inherit from this class or
+instantiate it directly to ensure that mock data generation is
+deterministic given the same seed value.
+"""
+
+from __future__ import annotations
+
+from random import Random
+from typing import Sequence, TypeVar
+
+T = TypeVar("T")
+
+
+class BaseGenerator:
+    """Base class providing seeded randomness utilities.
+
+    Parameters
+    ----------
+    seed:
+        Seed string used to initialize the underlying random number
+        generator.  Using a consistent seed across runs ensures
+        reproducibility of mock data streams, which is important for
+        debugging and deterministic tests.
+    """
+
+    def __init__(self, seed: str) -> None:
+        self._rng = Random(seed)
+
+    def choice(self, seq: Sequence[T]) -> T:
+        """Return a random element from *seq* using the seeded RNG."""
+        return self._rng.choice(list(seq))
+
+    def randint(self, a: int, b: int) -> int:
+        """Return random integer ``N`` such that ``a <= N <= b``."""
+        return self._rng.randint(a, b)

--- a/ingestion/rabbitmq_producers/orders/produce_orders_north.py
+++ b/ingestion/rabbitmq_producers/orders/produce_orders_north.py
@@ -2,7 +2,6 @@ import argparse
 import csv
 import json
 import os
-import random
 import time
 import uuid
 from datetime import datetime
@@ -12,8 +11,16 @@ from typing import Iterable
 import pika
 from pydantic import BaseModel, Field, ValidationError
 
+import sys
+from pathlib import Path as _Path
 
-random.seed("orders_order_created")
+# Ensure parent directory (with base_generator) is on path when executed as a script
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from base_generator import BaseGenerator
+
+
+rng = BaseGenerator("orders_order_created")
 
 
 class OrderEvent(BaseModel):
@@ -33,10 +40,10 @@ WAREHOUSES = ["WH-N1", "WH-N2", "WH-N3"]
 
 def generate_event() -> OrderEvent:
     """Generate a single order event."""
-    product_id = random.choice(PRODUCT_CATALOG)
-    warehouse_id = random.choice(WAREHOUSES)
+    product_id = rng.choice(PRODUCT_CATALOG)
+    warehouse_id = rng.choice(WAREHOUSES)
     order_ts = datetime.utcnow().isoformat()
-    qty = random.randint(1, 20)
+    qty = rng.randint(1, 20)
     return OrderEvent(product_id=product_id, warehouse_id=warehouse_id, order_ts=order_ts, qty=qty)
 
 


### PR DESCRIPTION
## Summary
- add a reusable BaseGenerator utility for deterministic seeded randomness
- update north-region order producer to leverage the seeded generator
- document progress in TODO list

## Testing
- `python -m py_compile ingestion/rabbitmq_producers/base_generator.py ingestion/rabbitmq_producers/orders/produce_orders_north.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f518387e0833098d924a76496228d