### PR TITLE
Add south region order producer and ingestion DAG

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,11 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
 * [x] Implement base generator class with reproducible seeded randomness
 * [ ] For each warehouse (`north`, `south`, `east`, `west`):
 
-  * [ ] `produce_orders_<region>.py`
+  * Orders generators:
+    * [x] `produce_orders_north.py`
+    * [x] `produce_orders_south.py`
+    * [ ] `produce_orders_east.py`
+    * [ ] `produce_orders_west.py`
   * [ ] `produce_returns_<region>.py`
   * [ ] `produce_inventory_<region>.py`
   * [ ] `produce_restocks_<region>.py`
@@ -57,7 +61,10 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
 * [ ] Create DAG bootstrap template (base class)
 * [ ] DAGs per domain:
 
-  * [ ] `ingest_<event>_<region>.py` → from RabbitMQ to Iceberg
+  * Ingestion DAGs:
+    * [x] `ingest_orders_north.py` → from RabbitMQ to Iceberg
+    * [x] `ingest_orders_south.py` → from RabbitMQ to Iceberg
+    * [ ] `ingest_<event>_<region>.py` → from RabbitMQ to Iceberg
   * [ ] `stg_<entity>.py` → transform raw to staging (via dbt)
   * [ ] `fact_<entity>.py` → load final fact tables
 * [ ] ML DAGs:

--- a/dags/orders_dags/ingest_orders_south.py
+++ b/dags/orders_dags/ingest_orders_south.py
@@ -1,0 +1,121 @@
+import json
+import logging
+import os
+from datetime import datetime, timedelta
+
+import pika
+import pyarrow as pa
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.utils.dates import days_ago
+from pydantic import BaseModel, ValidationError
+from pyiceberg.catalog import load_catalog
+from pyiceberg.table import Table
+
+from metadata.generated.schema.api.data.createTable import CreateTableRequest
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.ometa.openmetadata import OpenMetadata
+from metadata.ingestion.ometa.config import OpenMetadataServerConfig
+
+QUEUE_NAME = "orders_south"
+TABLE_FQN = "warehouse.fact_orders"
+CATALOG_NAME = os.getenv("ICEBERG_CATALOG", "local")
+
+
+class OrderEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    order_id: str
+    product_id: str
+    warehouse_id: str
+    order_ts: datetime
+    qty: int
+
+
+def register_with_openmetadata(rows_count: int) -> None:
+    server_config = OpenMetadataServerConfig(
+        hostPort=os.getenv("OPENMETADATA_HOSTPORT", "http://localhost:8585/api"),
+        authProvider="no-auth",
+    )
+    metadata = OpenMetadata(server_config)
+    request = CreateTableRequest(
+        name="fact_orders",
+        tableType="Regular",
+        columns=[
+            {"name": "event_id", "dataType": "STRING"},
+            {"name": "event_ts", "dataType": "TIMESTAMP"},
+            {"name": "event_type", "dataType": "STRING"},
+            {"name": "order_id", "dataType": "STRING"},
+            {"name": "product_id", "dataType": "STRING"},
+            {"name": "warehouse_id", "dataType": "STRING"},
+            {"name": "order_ts", "dataType": "TIMESTAMP"},
+            {"name": "qty", "dataType": "INT"},
+            {"name": "event_date", "dataType": "DATE"},
+        ],
+        owner=EntityReference(id="00000000-0000-0000-0000-000000000000", type="user"),
+        description="Orders fact table",
+    )
+    metadata.create_or_update(request)
+    logging.info("Registered %s rows to OpenMetadata", rows_count)
+
+
+def consume_and_write() -> None:
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"), os.getenv("RABBITMQ_PASSWORD", "guest")
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    channel.queue_declare(queue=QUEUE_NAME, durable=True)
+
+    rows = []
+    for method_frame, properties, body in channel.consume(QUEUE_NAME, inactivity_timeout=1):
+        if body is None:
+            break
+        try:
+            payload = json.loads(body)
+            event = OrderEvent(**payload)
+            record = event.dict()
+            record["event_date"] = event.order_ts.date().isoformat()
+            rows.append(record)
+            channel.basic_ack(method_frame.delivery_tag)
+        except ValidationError as exc:
+            logging.error("Validation error: %s", exc)
+            channel.basic_nack(method_frame.delivery_tag, requeue=False)
+
+    channel.close()
+    connection.close()
+
+    if not rows:
+        logging.info("No messages consumed")
+        return
+
+    catalog = load_catalog(CATALOG_NAME)
+    table: Table = catalog.load_table(TABLE_FQN)
+    table.append(pa.Table.from_pylist(rows))
+    register_with_openmetadata(len(rows))
+
+
+def build_dag() -> DAG:
+    with DAG(
+        dag_id="ingest_orders_south",
+        schedule_interval="@hourly",
+        start_date=days_ago(1),
+        catchup=False,
+        default_args={"owner": "data-eng", "retries": 1},
+    ) as dag:
+        consume = PythonOperator(
+            task_id="consume_orders",
+            python_callable=consume_and_write,
+            sla=timedelta(minutes=15),
+        )
+    return dag
+
+
+dag = build_dag()
+

--- a/ingestion/rabbitmq_producers/orders/produce_orders_south.py
+++ b/ingestion/rabbitmq_producers/orders/produce_orders_south.py
@@ -1,0 +1,130 @@
+import argparse
+import csv
+import json
+import os
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pika
+from pydantic import BaseModel, Field, ValidationError
+
+import sys
+from pathlib import Path as _Path
+
+# Ensure parent directory (with base_generator) is on path when executed as a script
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from base_generator import BaseGenerator
+
+
+rng = BaseGenerator("orders_order_created_south")
+
+
+class OrderEvent(BaseModel):
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    event_type: str = "order_created"
+    order_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    product_id: str
+    warehouse_id: str
+    order_ts: str
+    qty: int
+
+
+PRODUCT_CATALOG = [f"P{i:05d}" for i in range(1, 100)]
+WAREHOUSES = ["WH-S1", "WH-S2", "WH-S3"]
+
+
+def generate_event() -> OrderEvent:
+    """Generate a single order event."""
+    product_id = rng.choice(PRODUCT_CATALOG)
+    warehouse_id = rng.choice(WAREHOUSES)
+    order_ts = datetime.utcnow().isoformat()
+    qty = rng.randint(1, 20)
+    return OrderEvent(product_id=product_id, warehouse_id=warehouse_id, order_ts=order_ts, qty=qty)
+
+
+def publish_events(
+    channel: pika.adapters.blocking_connection.BlockingChannel,
+    queue: str,
+    events: Iterable[OrderEvent],
+) -> None:
+    for event in events:
+        try:
+            payload = event.json()
+            channel.basic_publish(exchange="", routing_key=queue, body=payload)
+            print(payload)
+        except ValidationError as exc:
+            print(f"Validation failed: {exc}")
+
+
+def live_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int
+) -> None:
+    while True:
+        publish_events(channel, queue, [generate_event()])
+        time.sleep(interval)
+
+
+def burst_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, count: int
+) -> None:
+    events = [generate_event() for _ in range(count)]
+    publish_events(channel, queue, events)
+
+
+def replay_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, path: Path
+) -> None:
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        events = []
+        for row in reader:
+            evt = OrderEvent(
+                product_id=row["product_id"],
+                warehouse_id=row["warehouse_id"],
+                order_ts=row["order_ts"],
+                qty=int(row["qty"]),
+            )
+            events.append(evt)
+        publish_events(channel, queue, events)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Produce order events for the south region")
+    parser.add_argument("--live", type=int, help="Emit events every N seconds")
+    parser.add_argument("--burst", type=int, help="Emit M events immediately")
+    parser.add_argument("--replay", type=Path, help="Replay events from a CSV file")
+    args = parser.parse_args()
+
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"), os.getenv("RABBITMQ_PASSWORD", "guest")
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    queue = "orders_south"
+    channel.queue_declare(queue=queue, durable=True)
+
+    if args.live:
+        live_mode(channel, queue, args.live)
+    elif args.burst:
+        burst_mode(channel, queue, args.burst)
+    elif args.replay:
+        replay_mode(channel, queue, args.replay)
+    else:
+        parser.error("One of --live, --burst, or --replay must be provided")
+
+    connection.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+


### PR DESCRIPTION
## Summary
- add south region RabbitMQ order event producer with seeded randomness and replay/burst/live modes
- add Airflow DAG to ingest south region order events into Iceberg and register metadata
- update TODO to reflect progress on south region generator and ingestion DAG

## Testing
- `pytest -q`
- `python -m py_compile ingestion/rabbitmq_producers/orders/produce_orders_south.py dags/orders_dags/ingest_orders_south.py`


------
https://chatgpt.com/codex/tasks/task_e_688f5241c4008330930f8b6ecb529aa2