### PR TITLE
Add east and west order generators

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -27,8 +27,8 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * Orders generators:
     * [x] `produce_orders_north.py`
     * [x] `produce_orders_south.py`
-    * [ ] `produce_orders_east.py`
-    * [ ] `produce_orders_west.py`
+    * [x] `produce_orders_east.py`
+    * [x] `produce_orders_west.py`
   * [ ] `produce_returns_<region>.py`
   * [ ] `produce_inventory_<region>.py`
   * [ ] `produce_restocks_<region>.py`

--- a/ingestion/rabbitmq_producers/orders/produce_orders_east.py
+++ b/ingestion/rabbitmq_producers/orders/produce_orders_east.py
@@ -1,0 +1,119 @@
+import argparse
+import csv
+import json
+import os
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pika
+from pydantic import BaseModel, Field, ValidationError
+
+import sys
+from pathlib import Path as _Path
+
+# Ensure parent directory (with base_generator) is on path when executed as a script
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from base_generator import BaseGenerator
+
+
+rng = BaseGenerator("orders_order_created_east")
+
+
+class OrderEvent(BaseModel):
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    event_type: str = "order_created"
+    order_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    product_id: str
+    warehouse_id: str
+    order_ts: str
+    qty: int
+
+
+PRODUCT_CATALOG = [f"P{i:05d}" for i in range(1, 100)]
+WAREHOUSES = ["WH-E1", "WH-E2", "WH-E3"]
+
+
+def generate_event() -> OrderEvent:
+    """Generate a single order event."""
+    product_id = rng.choice(PRODUCT_CATALOG)
+    warehouse_id = rng.choice(WAREHOUSES)
+    order_ts = datetime.utcnow().isoformat()
+    qty = rng.randint(1, 20)
+    return OrderEvent(product_id=product_id, warehouse_id=warehouse_id, order_ts=order_ts, qty=qty)
+
+
+def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, events: Iterable[OrderEvent]) -> None:
+    for event in events:
+        try:
+            payload = event.json()
+            channel.basic_publish(exchange="", routing_key=queue, body=payload)
+            print(payload)
+        except ValidationError as exc:
+            print(f"Validation failed: {exc}")
+
+
+def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:
+    while True:
+        publish_events(channel, queue, [generate_event()])
+        time.sleep(interval)
+
+
+def burst_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, count: int) -> None:
+    events = [generate_event() for _ in range(count)]
+    publish_events(channel, queue, events)
+
+
+def replay_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, path: Path) -> None:
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        events = []
+        for row in reader:
+            evt = OrderEvent(
+                product_id=row["product_id"],
+                warehouse_id=row["warehouse_id"],
+                order_ts=row["order_ts"],
+                qty=int(row["qty"]),
+            )
+            events.append(evt)
+        publish_events(channel, queue, events)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Produce order events for the east region")
+    parser.add_argument("--live", type=int, help="Emit events every N seconds")
+    parser.add_argument("--burst", type=int, help="Emit M events immediately")
+    parser.add_argument("--replay", type=Path, help="Replay events from a CSV file")
+    args = parser.parse_args()
+
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"), os.getenv("RABBITMQ_PASSWORD", "guest")
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    queue = "orders_east"
+    channel.queue_declare(queue=queue, durable=True)
+
+    if args.live:
+        live_mode(channel, queue, args.live)
+    elif args.burst:
+        burst_mode(channel, queue, args.burst)
+    elif args.replay:
+        replay_mode(channel, queue, args.replay)
+    else:
+        parser.error("One of --live, --burst, or --replay must be provided")
+
+    connection.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/ingestion/rabbitmq_producers/orders/produce_orders_west.py
+++ b/ingestion/rabbitmq_producers/orders/produce_orders_west.py
@@ -1,0 +1,119 @@
+import argparse
+import csv
+import json
+import os
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pika
+from pydantic import BaseModel, Field, ValidationError
+
+import sys
+from pathlib import Path as _Path
+
+# Ensure parent directory (with base_generator) is on path when executed as a script
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from base_generator import BaseGenerator
+
+
+rng = BaseGenerator("orders_order_created_west")
+
+
+class OrderEvent(BaseModel):
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    event_type: str = "order_created"
+    order_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    product_id: str
+    warehouse_id: str
+    order_ts: str
+    qty: int
+
+
+PRODUCT_CATALOG = [f"P{i:05d}" for i in range(1, 100)]
+WAREHOUSES = ["WH-W1", "WH-W2", "WH-W3"]
+
+
+def generate_event() -> OrderEvent:
+    """Generate a single order event."""
+    product_id = rng.choice(PRODUCT_CATALOG)
+    warehouse_id = rng.choice(WAREHOUSES)
+    order_ts = datetime.utcnow().isoformat()
+    qty = rng.randint(1, 20)
+    return OrderEvent(product_id=product_id, warehouse_id=warehouse_id, order_ts=order_ts, qty=qty)
+
+
+def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, events: Iterable[OrderEvent]) -> None:
+    for event in events:
+        try:
+            payload = event.json()
+            channel.basic_publish(exchange="", routing_key=queue, body=payload)
+            print(payload)
+        except ValidationError as exc:
+            print(f"Validation failed: {exc}")
+
+
+def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:
+    while True:
+        publish_events(channel, queue, [generate_event()])
+        time.sleep(interval)
+
+
+def burst_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, count: int) -> None:
+    events = [generate_event() for _ in range(count)]
+    publish_events(channel, queue, events)
+
+
+def replay_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, path: Path) -> None:
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        events = []
+        for row in reader:
+            evt = OrderEvent(
+                product_id=row["product_id"],
+                warehouse_id=row["warehouse_id"],
+                order_ts=row["order_ts"],
+                qty=int(row["qty"]),
+            )
+            events.append(evt)
+        publish_events(channel, queue, events)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Produce order events for the west region")
+    parser.add_argument("--live", type=int, help="Emit events every N seconds")
+    parser.add_argument("--burst", type=int, help="Emit M events immediately")
+    parser.add_argument("--replay", type=Path, help="Replay events from a CSV file")
+    args = parser.parse_args()
+
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"), os.getenv("RABBITMQ_PASSWORD", "guest")
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    queue = "orders_west"
+    channel.queue_declare(queue=queue, durable=True)
+
+    if args.live:
+        live_mode(channel, queue, args.live)
+    elif args.burst:
+        burst_mode(channel, queue, args.burst)
+    elif args.replay:
+        replay_mode(channel, queue, args.replay)
+    else:
+        parser.error("One of --live, --burst, or --replay must be provided")
+
+    connection.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add east and west order RabbitMQ producer scripts
- update TODO to reflect completion of east and west order generators

## Testing
- `python -m py_compile ingestion/rabbitmq_producers/base_generator.py ingestion/rabbitmq_producers/orders/produce_orders_east.py ingestion/rabbitmq_producers/orders/produce_orders_west.py`


------
https://chatgpt.com/codex/tasks/task_e_688f53709aa083308e1bcb350b4954ba