### PR TITLE
Implement order error event producers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] `produce_inventory_<region>.py`
   * [x] `produce_restocks_<region>.py`
   * [x] `produce_dispatch_logs_<region>.py`
-  * [ ] `produce_errors_<region>.py`
+  * [x] `produce_errors_<region>.py`
 * [ ] For `logistics_core` domain:
 
   * [ ] `produce_vehicle_tracking.py`

--- a/ingestion/rabbitmq_producers/errors/produce_errors_east.py
+++ b/ingestion/rabbitmq_producers/errors/produce_errors_east.py
@@ -1,0 +1,122 @@
+import argparse
+import csv
+import os
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pika
+from pydantic import BaseModel, Field, ValidationError
+
+import sys
+from pathlib import Path as _Path
+
+# Ensure parent directory (with base_generator) is on path when executed as a script
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from base_generator import BaseGenerator
+
+
+REGION = "east"
+rng = BaseGenerator(f"order_error_{REGION}")
+
+
+class OrderErrorEvent(BaseModel):
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    event_type: str = "order_error"
+    error_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    order_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    error_code: str
+    detected_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+ERROR_CODES = ["OUT_OF_STOCK", "PAYMENT_FAILED", "ADDRESS_INVALID", "UNKNOWN"]
+
+
+def generate_event() -> OrderErrorEvent:
+    error_code = rng.choice(ERROR_CODES)
+    return OrderErrorEvent(error_code=error_code)
+
+
+def publish_events(
+    channel: pika.adapters.blocking_connection.BlockingChannel,
+    queue: str,
+    events: Iterable[OrderErrorEvent],
+) -> None:
+    for event in events:
+        try:
+            payload = event.json()
+            channel.basic_publish(exchange="", routing_key=queue, body=payload)
+            print(payload)
+        except ValidationError as exc:
+            print(f"Validation failed: {exc}")
+
+
+def live_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int
+) -> None:
+    while True:
+        publish_events(channel, queue, [generate_event()])
+        time.sleep(interval)
+
+
+def burst_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, count: int
+) -> None:
+    events = [generate_event() for _ in range(count)]
+    publish_events(channel, queue, events)
+
+
+def replay_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, path: Path
+) -> None:
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        events = []
+        for row in reader:
+            evt = OrderErrorEvent(
+                order_id=row["order_id"],
+                error_code=row["error_code"],
+                detected_ts=row["detected_ts"],
+            )
+            events.append(evt)
+        publish_events(channel, queue, events)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Produce order error events for the east region")
+    parser.add_argument("--live", type=int, help="Emit events every N seconds")
+    parser.add_argument("--burst", type=int, help="Emit M events immediately")
+    parser.add_argument("--replay", type=Path, help="Replay events from a CSV file")
+    args = parser.parse_args()
+
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"), os.getenv("RABBITMQ_PASSWORD", "guest")
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    queue = f"errors_{REGION}"
+    channel.queue_declare(queue=queue, durable=True)
+
+    if args.live:
+        live_mode(channel, queue, args.live)
+    elif args.burst:
+        burst_mode(channel, queue, args.burst)
+    elif args.replay:
+        replay_mode(channel, queue, args.replay)
+    else:
+        parser.error("One of --live, --burst, or --replay must be provided")
+
+    connection.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/ingestion/rabbitmq_producers/errors/produce_errors_north.py
+++ b/ingestion/rabbitmq_producers/errors/produce_errors_north.py
@@ -1,0 +1,122 @@
+import argparse
+import csv
+import os
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pika
+from pydantic import BaseModel, Field, ValidationError
+
+import sys
+from pathlib import Path as _Path
+
+# Ensure parent directory (with base_generator) is on path when executed as a script
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from base_generator import BaseGenerator
+
+
+REGION = "north"
+rng = BaseGenerator(f"order_error_{REGION}")
+
+
+class OrderErrorEvent(BaseModel):
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    event_type: str = "order_error"
+    error_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    order_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    error_code: str
+    detected_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+ERROR_CODES = ["OUT_OF_STOCK", "PAYMENT_FAILED", "ADDRESS_INVALID", "UNKNOWN"]
+
+
+def generate_event() -> OrderErrorEvent:
+    error_code = rng.choice(ERROR_CODES)
+    return OrderErrorEvent(error_code=error_code)
+
+
+def publish_events(
+    channel: pika.adapters.blocking_connection.BlockingChannel,
+    queue: str,
+    events: Iterable[OrderErrorEvent],
+) -> None:
+    for event in events:
+        try:
+            payload = event.json()
+            channel.basic_publish(exchange="", routing_key=queue, body=payload)
+            print(payload)
+        except ValidationError as exc:
+            print(f"Validation failed: {exc}")
+
+
+def live_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int
+) -> None:
+    while True:
+        publish_events(channel, queue, [generate_event()])
+        time.sleep(interval)
+
+
+def burst_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, count: int
+) -> None:
+    events = [generate_event() for _ in range(count)]
+    publish_events(channel, queue, events)
+
+
+def replay_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, path: Path
+) -> None:
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        events = []
+        for row in reader:
+            evt = OrderErrorEvent(
+                order_id=row["order_id"],
+                error_code=row["error_code"],
+                detected_ts=row["detected_ts"],
+            )
+            events.append(evt)
+        publish_events(channel, queue, events)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Produce order error events for the north region")
+    parser.add_argument("--live", type=int, help="Emit events every N seconds")
+    parser.add_argument("--burst", type=int, help="Emit M events immediately")
+    parser.add_argument("--replay", type=Path, help="Replay events from a CSV file")
+    args = parser.parse_args()
+
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"), os.getenv("RABBITMQ_PASSWORD", "guest")
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    queue = f"errors_{REGION}"
+    channel.queue_declare(queue=queue, durable=True)
+
+    if args.live:
+        live_mode(channel, queue, args.live)
+    elif args.burst:
+        burst_mode(channel, queue, args.burst)
+    elif args.replay:
+        replay_mode(channel, queue, args.replay)
+    else:
+        parser.error("One of --live, --burst, or --replay must be provided")
+
+    connection.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/ingestion/rabbitmq_producers/errors/produce_errors_south.py
+++ b/ingestion/rabbitmq_producers/errors/produce_errors_south.py
@@ -1,0 +1,122 @@
+import argparse
+import csv
+import os
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pika
+from pydantic import BaseModel, Field, ValidationError
+
+import sys
+from pathlib import Path as _Path
+
+# Ensure parent directory (with base_generator) is on path when executed as a script
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from base_generator import BaseGenerator
+
+
+REGION = "south"
+rng = BaseGenerator(f"order_error_{REGION}")
+
+
+class OrderErrorEvent(BaseModel):
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    event_type: str = "order_error"
+    error_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    order_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    error_code: str
+    detected_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+ERROR_CODES = ["OUT_OF_STOCK", "PAYMENT_FAILED", "ADDRESS_INVALID", "UNKNOWN"]
+
+
+def generate_event() -> OrderErrorEvent:
+    error_code = rng.choice(ERROR_CODES)
+    return OrderErrorEvent(error_code=error_code)
+
+
+def publish_events(
+    channel: pika.adapters.blocking_connection.BlockingChannel,
+    queue: str,
+    events: Iterable[OrderErrorEvent],
+) -> None:
+    for event in events:
+        try:
+            payload = event.json()
+            channel.basic_publish(exchange="", routing_key=queue, body=payload)
+            print(payload)
+        except ValidationError as exc:
+            print(f"Validation failed: {exc}")
+
+
+def live_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int
+) -> None:
+    while True:
+        publish_events(channel, queue, [generate_event()])
+        time.sleep(interval)
+
+
+def burst_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, count: int
+) -> None:
+    events = [generate_event() for _ in range(count)]
+    publish_events(channel, queue, events)
+
+
+def replay_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, path: Path
+) -> None:
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        events = []
+        for row in reader:
+            evt = OrderErrorEvent(
+                order_id=row["order_id"],
+                error_code=row["error_code"],
+                detected_ts=row["detected_ts"],
+            )
+            events.append(evt)
+        publish_events(channel, queue, events)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Produce order error events for the south region")
+    parser.add_argument("--live", type=int, help="Emit events every N seconds")
+    parser.add_argument("--burst", type=int, help="Emit M events immediately")
+    parser.add_argument("--replay", type=Path, help="Replay events from a CSV file")
+    args = parser.parse_args()
+
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"), os.getenv("RABBITMQ_PASSWORD", "guest")
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    queue = f"errors_{REGION}"
+    channel.queue_declare(queue=queue, durable=True)
+
+    if args.live:
+        live_mode(channel, queue, args.live)
+    elif args.burst:
+        burst_mode(channel, queue, args.burst)
+    elif args.replay:
+        replay_mode(channel, queue, args.replay)
+    else:
+        parser.error("One of --live, --burst, or --replay must be provided")
+
+    connection.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/ingestion/rabbitmq_producers/errors/produce_errors_west.py
+++ b/ingestion/rabbitmq_producers/errors/produce_errors_west.py
@@ -1,0 +1,122 @@
+import argparse
+import csv
+import os
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pika
+from pydantic import BaseModel, Field, ValidationError
+
+import sys
+from pathlib import Path as _Path
+
+# Ensure parent directory (with base_generator) is on path when executed as a script
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from base_generator import BaseGenerator
+
+
+REGION = "west"
+rng = BaseGenerator(f"order_error_{REGION}")
+
+
+class OrderErrorEvent(BaseModel):
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    event_type: str = "order_error"
+    error_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    order_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    error_code: str
+    detected_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+ERROR_CODES = ["OUT_OF_STOCK", "PAYMENT_FAILED", "ADDRESS_INVALID", "UNKNOWN"]
+
+
+def generate_event() -> OrderErrorEvent:
+    error_code = rng.choice(ERROR_CODES)
+    return OrderErrorEvent(error_code=error_code)
+
+
+def publish_events(
+    channel: pika.adapters.blocking_connection.BlockingChannel,
+    queue: str,
+    events: Iterable[OrderErrorEvent],
+) -> None:
+    for event in events:
+        try:
+            payload = event.json()
+            channel.basic_publish(exchange="", routing_key=queue, body=payload)
+            print(payload)
+        except ValidationError as exc:
+            print(f"Validation failed: {exc}")
+
+
+def live_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int
+) -> None:
+    while True:
+        publish_events(channel, queue, [generate_event()])
+        time.sleep(interval)
+
+
+def burst_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, count: int
+) -> None:
+    events = [generate_event() for _ in range(count)]
+    publish_events(channel, queue, events)
+
+
+def replay_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, path: Path
+) -> None:
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        events = []
+        for row in reader:
+            evt = OrderErrorEvent(
+                order_id=row["order_id"],
+                error_code=row["error_code"],
+                detected_ts=row["detected_ts"],
+            )
+            events.append(evt)
+        publish_events(channel, queue, events)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Produce order error events for the west region")
+    parser.add_argument("--live", type=int, help="Emit events every N seconds")
+    parser.add_argument("--burst", type=int, help="Emit M events immediately")
+    parser.add_argument("--replay", type=Path, help="Replay events from a CSV file")
+    args = parser.parse_args()
+
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"), os.getenv("RABBITMQ_PASSWORD", "guest")
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    queue = f"errors_{REGION}"
+    channel.queue_declare(queue=queue, durable=True)
+
+    if args.live:
+        live_mode(channel, queue, args.live)
+    elif args.burst:
+        burst_mode(channel, queue, args.burst)
+    elif args.replay:
+        replay_mode(channel, queue, args.replay)
+    else:
+        parser.error("One of --live, --burst, or --replay must be provided")
+
+    connection.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add RabbitMQ producers for order error events across all four regions
- update TODO to reflect completion of error event producers

## Testing
- `python -m py_compile ingestion/rabbitmq_producers/errors/produce_errors_*.py`


------
https://chatgpt.com/codex/tasks/task_e_688f5933cde883308db3fb16450630a4