### PR TITLE
Add logistics core event producers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,11 +34,11 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] `produce_restocks_<region>.py`
   * [x] `produce_dispatch_logs_<region>.py`
   * [x] `produce_errors_<region>.py`
-* [ ] For `logistics_core` domain:
+* [x] For `logistics_core` domain:
 
-  * [ ] `produce_vehicle_tracking.py`
-  * [ ] `produce_route_updates.py`
-  * [ ] `produce_delivery_sla.py`
+  * [x] `produce_vehicle_tracking.py`
+  * [x] `produce_route_updates.py`
+  * [x] `produce_delivery_sla.py`
 * [ ] For `ml_insights` domain:
 
   * [ ] `produce_demand_forecast.py`

--- a/ingestion/rabbitmq_producers/logistics_core/produce_delivery_sla.py
+++ b/ingestion/rabbitmq_producers/logistics_core/produce_delivery_sla.py
@@ -1,0 +1,127 @@
+import argparse
+import csv
+import os
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pika
+from pydantic import BaseModel, Field, ValidationError
+
+import sys
+from pathlib import Path as _Path
+
+# Ensure parent directory (with base_generator) is on path when executed as a script
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from base_generator import BaseGenerator
+
+
+rng = BaseGenerator("logistics_delivery_sla")
+
+
+class DeliverySLAEvent(BaseModel):
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    event_type: str = "delivery_sla"
+    order_id: str
+    vehicle_id: str
+    sla_minutes: int
+    actual_minutes: int
+
+
+ORDERS = [f"ORD-{i:05d}" for i in range(1, 200)]
+VEHICLES = [f"VEH-{i:03d}" for i in range(1, 50)]
+
+
+def generate_event() -> DeliverySLAEvent:
+    order_id = rng.choice(ORDERS)
+    vehicle_id = rng.choice(VEHICLES)
+    sla_minutes = rng.randint(30, 240)
+    actual_minutes = max(0, sla_minutes + rng.randint(-30, 60))
+    return DeliverySLAEvent(
+        order_id=order_id,
+        vehicle_id=vehicle_id,
+        sla_minutes=sla_minutes,
+        actual_minutes=actual_minutes,
+    )
+
+
+def publish_events(
+    channel: pika.adapters.blocking_connection.BlockingChannel,
+    queue: str,
+    events: Iterable[DeliverySLAEvent],
+) -> None:
+    for event in events:
+        try:
+            payload = event.json()
+            channel.basic_publish(exchange="", routing_key=queue, body=payload)
+            print(payload)
+        except ValidationError as exc:
+            print(f"Validation failed: {exc}")
+
+
+def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:
+    while True:
+        publish_events(channel, queue, [generate_event()])
+        time.sleep(interval)
+
+
+def burst_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, count: int) -> None:
+    events = [generate_event() for _ in range(count)]
+    publish_events(channel, queue, events)
+
+
+def replay_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, path: Path
+) -> None:
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        events = []
+        for row in reader:
+            evt = DeliverySLAEvent(
+                order_id=row["order_id"],
+                vehicle_id=row["vehicle_id"],
+                sla_minutes=int(row["sla_minutes"]),
+                actual_minutes=int(row["actual_minutes"]),
+            )
+            events.append(evt)
+        publish_events(channel, queue, events)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Produce delivery SLA events")
+    parser.add_argument("--live", type=int, help="Emit events every N seconds")
+    parser.add_argument("--burst", type=int, help="Emit M events immediately")
+    parser.add_argument("--replay", type=Path, help="Replay events from a CSV file")
+    args = parser.parse_args()
+
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"), os.getenv("RABBITMQ_PASSWORD", "guest")
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    queue = "delivery_sla"
+    channel.queue_declare(queue=queue, durable=True)
+
+    if args.live:
+        live_mode(channel, queue, args.live)
+    elif args.burst:
+        burst_mode(channel, queue, args.burst)
+    elif args.replay:
+        replay_mode(channel, queue, args.replay)
+    else:
+        parser.error("One of --live, --burst, or --replay must be provided")
+
+    connection.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/ingestion/rabbitmq_producers/logistics_core/produce_route_updates.py
+++ b/ingestion/rabbitmq_producers/logistics_core/produce_route_updates.py
@@ -1,0 +1,114 @@
+import argparse
+import csv
+import os
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pika
+from pydantic import BaseModel, Field, ValidationError
+
+import sys
+from pathlib import Path as _Path
+
+# Ensure parent directory (with base_generator) is on path when executed as a script
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from base_generator import BaseGenerator
+
+
+rng = BaseGenerator("logistics_route_update")
+
+
+class RouteUpdateEvent(BaseModel):
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    event_type: str = "route_update"
+    route_id: str
+    status: str
+    updated_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+ROUTES = [f"ROUTE-{i:04d}" for i in range(1, 100)]
+STATUSES = ["ASSIGNED", "IN_TRANSIT", "DELIVERED", "DELAYED"]
+
+
+def generate_event() -> RouteUpdateEvent:
+    route_id = rng.choice(ROUTES)
+    status = rng.choice(STATUSES)
+    return RouteUpdateEvent(route_id=route_id, status=status)
+
+
+def publish_events(
+    channel: pika.adapters.blocking_connection.BlockingChannel,
+    queue: str,
+    events: Iterable[RouteUpdateEvent],
+) -> None:
+    for event in events:
+        try:
+            payload = event.json()
+            channel.basic_publish(exchange="", routing_key=queue, body=payload)
+            print(payload)
+        except ValidationError as exc:
+            print(f"Validation failed: {exc}")
+
+
+def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:
+    while True:
+        publish_events(channel, queue, [generate_event()])
+        time.sleep(interval)
+
+
+def burst_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, count: int) -> None:
+    events = [generate_event() for _ in range(count)]
+    publish_events(channel, queue, events)
+
+
+def replay_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, path: Path
+) -> None:
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        events = []
+        for row in reader:
+            evt = RouteUpdateEvent(route_id=row["route_id"], status=row["status"], updated_ts=row.get("updated_ts", datetime.utcnow().isoformat()))
+            events.append(evt)
+        publish_events(channel, queue, events)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Produce route update events")
+    parser.add_argument("--live", type=int, help="Emit events every N seconds")
+    parser.add_argument("--burst", type=int, help="Emit M events immediately")
+    parser.add_argument("--replay", type=Path, help="Replay events from a CSV file")
+    args = parser.parse_args()
+
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"), os.getenv("RABBITMQ_PASSWORD", "guest")
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    queue = "route_updates"
+    channel.queue_declare(queue=queue, durable=True)
+
+    if args.live:
+        live_mode(channel, queue, args.live)
+    elif args.burst:
+        burst_mode(channel, queue, args.burst)
+    elif args.replay:
+        replay_mode(channel, queue, args.replay)
+    else:
+        parser.error("One of --live, --burst, or --replay must be provided")
+
+    connection.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/ingestion/rabbitmq_producers/logistics_core/produce_vehicle_tracking.py
+++ b/ingestion/rabbitmq_producers/logistics_core/produce_vehicle_tracking.py
@@ -1,0 +1,124 @@
+import argparse
+import csv
+import json
+import os
+import time
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pika
+from pydantic import BaseModel, Field, ValidationError
+
+import sys
+from pathlib import Path as _Path
+
+# Ensure parent directory (with base_generator) is on path when executed as a script
+sys.path.append(str(_Path(__file__).resolve().parents[1]))
+
+from base_generator import BaseGenerator
+
+
+rng = BaseGenerator("logistics_vehicle_tracking")
+
+
+class VehicleTrackingEvent(BaseModel):
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    event_ts: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    event_type: str = "vehicle_tracking"
+    vehicle_id: str
+    latitude: float
+    longitude: float
+    speed_kph: int
+
+
+VEHICLES = [f"VEH-{i:03d}" for i in range(1, 50)]
+
+
+def generate_event() -> VehicleTrackingEvent:
+    vehicle_id = rng.choice(VEHICLES)
+    latitude = rng.randint(-9000, 9000) / 100.0
+    longitude = rng.randint(-18000, 18000) / 100.0
+    speed_kph = rng.randint(0, 120)
+    return VehicleTrackingEvent(
+        vehicle_id=vehicle_id, latitude=latitude, longitude=longitude, speed_kph=speed_kph
+    )
+
+
+def publish_events(
+    channel: pika.adapters.blocking_connection.BlockingChannel,
+    queue: str,
+    events: Iterable[VehicleTrackingEvent],
+) -> None:
+    for event in events:
+        try:
+            payload = event.json()
+            channel.basic_publish(exchange="", routing_key=queue, body=payload)
+            print(payload)
+        except ValidationError as exc:
+            print(f"Validation failed: {exc}")
+
+
+def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:
+    while True:
+        publish_events(channel, queue, [generate_event()])
+        time.sleep(interval)
+
+
+def burst_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, count: int) -> None:
+    events = [generate_event() for _ in range(count)]
+    publish_events(channel, queue, events)
+
+
+def replay_mode(
+    channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, path: Path
+) -> None:
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        events = []
+        for row in reader:
+            evt = VehicleTrackingEvent(
+                vehicle_id=row["vehicle_id"],
+                latitude=float(row["latitude"]),
+                longitude=float(row["longitude"]),
+                speed_kph=int(row["speed_kph"]),
+            )
+            events.append(evt)
+        publish_events(channel, queue, events)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Produce vehicle tracking events")
+    parser.add_argument("--live", type=int, help="Emit events every N seconds")
+    parser.add_argument("--burst", type=int, help="Emit M events immediately")
+    parser.add_argument("--replay", type=Path, help="Replay events from a CSV file")
+    args = parser.parse_args()
+
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"), os.getenv("RABBITMQ_PASSWORD", "guest")
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    queue = "vehicle_tracking"
+    channel.queue_declare(queue=queue, durable=True)
+
+    if args.live:
+        live_mode(channel, queue, args.live)
+    elif args.burst:
+        burst_mode(channel, queue, args.burst)
+    elif args.replay:
+        replay_mode(channel, queue, args.replay)
+    else:
+        parser.error("One of --live, --burst, or --replay must be provided")
+
+    connection.close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add vehicle tracking, route update, and delivery SLA RabbitMQ producers for the logistics core domain
- mark logistics core tasks complete in TODO

## Testing
- `python -m py_compile ingestion/rabbitmq_producers/logistics_core/produce_vehicle_tracking.py ingestion/rabbitmq_producers/logistics_core/produce_route_updates.py ingestion/rabbitmq_producers/logistics_core/produce_delivery_sla.py`


------
https://chatgpt.com/codex/tasks/task_e_688f5a1cfab0833096eca251e01892b8