### PR TITLE
Implement return DAGs for all regions and add vehicle dimension schema

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,11 +53,13 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
   * [x] `dim_warehouse`
+  * [x] `dim_vehicle`
 * [ ] Partitioning strategy: use `event_date` for all `fact_` tables
 * [ ] Create Iceberg DDLs for DuckDB queries
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
   * [x] `dim_warehouse`
+  * [x] `dim_vehicle`
 * [ ] Create YAML specs for dbt models
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
@@ -75,6 +77,9 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
     * [x] `ingest_orders_east.py` → from RabbitMQ to Iceberg
     * [x] `ingest_orders_west.py` → from RabbitMQ to Iceberg
     * [x] `ingest_returns_north.py` → from RabbitMQ to Iceberg
+    * [x] `ingest_returns_south.py` → from RabbitMQ to Iceberg
+    * [x] `ingest_returns_east.py` → from RabbitMQ to Iceberg
+    * [x] `ingest_returns_west.py` → from RabbitMQ to Iceberg
     * [ ] `ingest_<event>_<region>.py` → from RabbitMQ to Iceberg
   * [ ] `stg_<entity>.py` → transform raw to staging (via dbt)
   * [ ] `fact_<entity>.py` → load final fact tables

--- a/dags/returns_dags/ingest_returns_east.py
+++ b/dags/returns_dags/ingest_returns_east.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+from dags.base_ingest import build_ingest_dag
+
+
+class ReturnEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    return_id: str
+    order_id: str
+    return_ts: datetime
+    reason_code: str
+
+
+columns = [
+    {"name": "event_id", "dataType": "STRING"},
+    {"name": "event_ts", "dataType": "TIMESTAMP"},
+    {"name": "event_type", "dataType": "STRING"},
+    {"name": "return_id", "dataType": "STRING"},
+    {"name": "order_id", "dataType": "STRING"},
+    {"name": "return_ts", "dataType": "TIMESTAMP"},
+    {"name": "reason_code", "dataType": "STRING"},
+]
+
+
+dag = build_ingest_dag(
+    dag_id="ingest_returns_east",
+    queue_name="returns_east",
+    table_fqn="warehouse.fact_returns",
+    event_model=ReturnEvent,
+    columns=columns,
+    table_description="Returns fact table",
+    date_field="return_ts",
+)

--- a/dags/returns_dags/ingest_returns_south.py
+++ b/dags/returns_dags/ingest_returns_south.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+from dags.base_ingest import build_ingest_dag
+
+
+class ReturnEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    return_id: str
+    order_id: str
+    return_ts: datetime
+    reason_code: str
+
+
+columns = [
+    {"name": "event_id", "dataType": "STRING"},
+    {"name": "event_ts", "dataType": "TIMESTAMP"},
+    {"name": "event_type", "dataType": "STRING"},
+    {"name": "return_id", "dataType": "STRING"},
+    {"name": "order_id", "dataType": "STRING"},
+    {"name": "return_ts", "dataType": "TIMESTAMP"},
+    {"name": "reason_code", "dataType": "STRING"},
+]
+
+
+dag = build_ingest_dag(
+    dag_id="ingest_returns_south",
+    queue_name="returns_south",
+    table_fqn="warehouse.fact_returns",
+    event_model=ReturnEvent,
+    columns=columns,
+    table_description="Returns fact table",
+    date_field="return_ts",
+)

--- a/dags/returns_dags/ingest_returns_west.py
+++ b/dags/returns_dags/ingest_returns_west.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+from dags.base_ingest import build_ingest_dag
+
+
+class ReturnEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    return_id: str
+    order_id: str
+    return_ts: datetime
+    reason_code: str
+
+
+columns = [
+    {"name": "event_id", "dataType": "STRING"},
+    {"name": "event_ts", "dataType": "TIMESTAMP"},
+    {"name": "event_type", "dataType": "STRING"},
+    {"name": "return_id", "dataType": "STRING"},
+    {"name": "order_id", "dataType": "STRING"},
+    {"name": "return_ts", "dataType": "TIMESTAMP"},
+    {"name": "reason_code", "dataType": "STRING"},
+]
+
+
+dag = build_ingest_dag(
+    dag_id="ingest_returns_west",
+    queue_name="returns_west",
+    table_fqn="warehouse.fact_returns",
+    event_model=ReturnEvent,
+    columns=columns,
+    table_description="Returns fact table",
+    date_field="return_ts",
+)

--- a/models/sql/dim_vehicle.sql
+++ b/models/sql/dim_vehicle.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS iceberg.dim_vehicle (
+    vehicle_id STRING,
+    type STRING,
+    capacity INT,
+    current_location STRING,
+    event_date DATE
+)
+USING iceberg
+PARTITIONED BY (event_date);


### PR DESCRIPTION
## Summary
- add missing ingestion DAGs for returns in south, east, and west regions
- define Iceberg DDL for `dim_vehicle`
- mark related tasks complete in TODO

## Testing
- `python -m py_compile dags/returns_dags/ingest_returns_south.py dags/returns_dags/ingest_returns_east.py dags/returns_dags/ingest_returns_west.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f60043f048330ac051287ef802d1e