### PR TITLE
Add dispatch logs ingestion DAG and schemas

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,16 +50,24 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
 ## 🗂️ Data Modeling
 
 * [ ] Create Iceberg-compatible schemas for all `fact_` and `dim_` tables (match `AGENTS.md`)
+  * [x] `fact_orders`
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
+  * [x] `fact_dispatch_logs`
   * [x] `dim_warehouse`
   * [x] `dim_vehicle`
+  * [x] `dim_product`
+  * [x] `dim_route`
 * [ ] Partitioning strategy: use `event_date` for all `fact_` tables
 * [ ] Create Iceberg DDLs for DuckDB queries
+  * [x] `fact_orders`
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
+  * [x] `fact_dispatch_logs`
   * [x] `dim_warehouse`
   * [x] `dim_vehicle`
+  * [x] `dim_product`
+  * [x] `dim_route`
 * [ ] Create YAML specs for dbt models
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
@@ -80,6 +88,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
     * [x] `ingest_returns_south.py` → from RabbitMQ to Iceberg
     * [x] `ingest_returns_east.py` → from RabbitMQ to Iceberg
     * [x] `ingest_returns_west.py` → from RabbitMQ to Iceberg
+    * [x] `ingest_dispatch_logs_north.py` → from RabbitMQ to Iceberg
     * [ ] `ingest_<event>_<region>.py` → from RabbitMQ to Iceberg
   * [ ] `stg_<entity>.py` → transform raw to staging (via dbt)
   * [ ] `fact_<entity>.py` → load final fact tables

--- a/dags/dispatch_logs_dags/ingest_dispatch_logs_north.py
+++ b/dags/dispatch_logs_dags/ingest_dispatch_logs_north.py
@@ -1,0 +1,121 @@
+import json
+import logging
+import os
+from datetime import datetime, timedelta
+
+import pika
+import pyarrow as pa
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.utils.dates import days_ago
+from pydantic import BaseModel, ValidationError
+from pyiceberg.catalog import load_catalog
+from pyiceberg.table import Table
+
+from metadata.generated.schema.api.data.createTable import CreateTableRequest
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.ometa.openmetadata import OpenMetadata
+from metadata.ingestion.ometa.config import OpenMetadataServerConfig
+
+QUEUE_NAME = "dispatch_logs_north"
+TABLE_FQN = "warehouse.fact_dispatch_logs"
+CATALOG_NAME = os.getenv("ICEBERG_CATALOG", "local")
+
+
+class DispatchLogEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    dispatch_id: str
+    order_id: str
+    vehicle_id: str
+    status: str
+    eta: datetime
+
+
+def register_with_openmetadata(rows_count: int) -> None:
+    server_config = OpenMetadataServerConfig(
+        hostPort=os.getenv("OPENMETADATA_HOSTPORT", "http://localhost:8585/api"),
+        authProvider="no-auth",
+    )
+    metadata = OpenMetadata(server_config)
+    request = CreateTableRequest(
+        name="fact_dispatch_logs",
+        tableType="Regular",
+        columns=[
+            {"name": "event_id", "dataType": "STRING"},
+            {"name": "event_ts", "dataType": "TIMESTAMP"},
+            {"name": "event_type", "dataType": "STRING"},
+            {"name": "dispatch_id", "dataType": "STRING"},
+            {"name": "order_id", "dataType": "STRING"},
+            {"name": "vehicle_id", "dataType": "STRING"},
+            {"name": "status", "dataType": "STRING"},
+            {"name": "eta", "dataType": "TIMESTAMP"},
+            {"name": "event_date", "dataType": "DATE"},
+        ],
+        owner=EntityReference(id="00000000-0000-0000-0000-000000000000", type="user"),
+        description="Dispatch logs fact table",
+    )
+    metadata.create_or_update(request)
+    logging.info("Registered %s rows to OpenMetadata", rows_count)
+
+
+def consume_and_write() -> None:
+    credentials = pika.PlainCredentials(
+        os.getenv("RABBITMQ_USER", "guest"),
+        os.getenv("RABBITMQ_PASSWORD", "guest"),
+    )
+    parameters = pika.ConnectionParameters(
+        host=os.getenv("RABBITMQ_HOST", "localhost"),
+        port=int(os.getenv("RABBITMQ_PORT", "5672")),
+        credentials=credentials,
+    )
+    connection = pika.BlockingConnection(parameters)
+    channel = connection.channel()
+    channel.queue_declare(queue=QUEUE_NAME, durable=True)
+
+    rows = []
+    for method_frame, properties, body in channel.consume(QUEUE_NAME, inactivity_timeout=1):
+        if body is None:
+            break
+        try:
+            payload = json.loads(body)
+            event = DispatchLogEvent(**payload)
+            record = event.dict()
+            record["event_date"] = event.event_ts.date().isoformat()
+            rows.append(record)
+            channel.basic_ack(method_frame.delivery_tag)
+        except ValidationError as exc:
+            logging.error("Validation error: %s", exc)
+            channel.basic_nack(method_frame.delivery_tag, requeue=False)
+
+    channel.close()
+    connection.close()
+
+    if not rows:
+        logging.info("No messages consumed")
+        return
+
+    catalog = load_catalog(CATALOG_NAME)
+    table: Table = catalog.load_table(TABLE_FQN)
+    table.append(pa.Table.from_pylist(rows))
+    register_with_openmetadata(len(rows))
+
+
+def build_dag() -> DAG:
+    with DAG(
+        dag_id="ingest_dispatch_logs_north",
+        schedule_interval="@hourly",
+        start_date=days_ago(1),
+        catchup=False,
+        default_args={"owner": "data-eng", "retries": 1},
+    ) as dag:
+        PythonOperator(
+            task_id="consume_dispatch_logs",
+            python_callable=consume_and_write,
+            sla=timedelta(minutes=15),
+        )
+    return dag
+
+
+dag = build_dag()

--- a/models/sql/dim_route.sql
+++ b/models/sql/dim_route.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS iceberg.dim_route (
+    route_id STRING,
+    region_covered STRING,
+    avg_duration INT,
+    event_date DATE
+)
+USING iceberg
+PARTITIONED BY (event_date);

--- a/models/sql/fact_dispatch_logs.sql
+++ b/models/sql/fact_dispatch_logs.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS iceberg.fact_dispatch_logs (
+    event_id STRING,
+    event_ts TIMESTAMP,
+    event_type STRING,
+    dispatch_id STRING,
+    order_id STRING,
+    vehicle_id STRING,
+    status STRING,
+    eta TIMESTAMP,
+    event_date DATE
+)
+USING iceberg
+PARTITIONED BY (event_date);


### PR DESCRIPTION
## Summary
- add ingest_dispatch_logs_north DAG to consume dispatch log events into Iceberg and register metadata
- define Iceberg tables for fact_dispatch_logs and dim_route
- update TODO to reflect new schemas and DAG progress

## Testing
- `python -m py_compile dags/dispatch_logs_dags/ingest_dispatch_logs_north.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f613a74448330b2452d8013b8c29e