### PR TITLE
Add dispatch log ingestion DAGs for all regions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -89,6 +89,9 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
     * [x] `ingest_returns_east.py` → from RabbitMQ to Iceberg
     * [x] `ingest_returns_west.py` → from RabbitMQ to Iceberg
     * [x] `ingest_dispatch_logs_north.py` → from RabbitMQ to Iceberg
+    * [x] `ingest_dispatch_logs_south.py` → from RabbitMQ to Iceberg
+    * [x] `ingest_dispatch_logs_east.py` → from RabbitMQ to Iceberg
+    * [x] `ingest_dispatch_logs_west.py` → from RabbitMQ to Iceberg
     * [ ] `ingest_<event>_<region>.py` → from RabbitMQ to Iceberg
   * [ ] `stg_<entity>.py` → transform raw to staging (via dbt)
   * [ ] `fact_<entity>.py` → load final fact tables

--- a/dags/dispatch_logs_dags/ingest_dispatch_logs_east.py
+++ b/dags/dispatch_logs_dags/ingest_dispatch_logs_east.py
@@ -1,0 +1,40 @@
+"""Ingest dispatch log events from RabbitMQ to Iceberg for east region."""
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from dags.base_ingest import build_ingest_dag
+
+
+class DispatchLogEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    dispatch_id: str
+    order_id: str
+    vehicle_id: str
+    status: str
+    eta: datetime
+
+
+COLUMNS = [
+    {"name": "event_id", "dataType": "STRING"},
+    {"name": "event_ts", "dataType": "TIMESTAMP"},
+    {"name": "event_type", "dataType": "STRING"},
+    {"name": "dispatch_id", "dataType": "STRING"},
+    {"name": "order_id", "dataType": "STRING"},
+    {"name": "vehicle_id", "dataType": "STRING"},
+    {"name": "status", "dataType": "STRING"},
+    {"name": "eta", "dataType": "TIMESTAMP"},
+]
+
+
+dag = build_ingest_dag(
+    dag_id="ingest_dispatch_logs_east",
+    queue_name="dispatch_logs_east",
+    table_fqn="warehouse.fact_dispatch_logs",
+    event_model=DispatchLogEvent,
+    columns=COLUMNS,
+    table_description="Dispatch logs fact table",
+    date_field="event_ts",
+)

--- a/dags/dispatch_logs_dags/ingest_dispatch_logs_south.py
+++ b/dags/dispatch_logs_dags/ingest_dispatch_logs_south.py
@@ -1,0 +1,40 @@
+"""Ingest dispatch log events from RabbitMQ to Iceberg for south region."""
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from dags.base_ingest import build_ingest_dag
+
+
+class DispatchLogEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    dispatch_id: str
+    order_id: str
+    vehicle_id: str
+    status: str
+    eta: datetime
+
+
+COLUMNS = [
+    {"name": "event_id", "dataType": "STRING"},
+    {"name": "event_ts", "dataType": "TIMESTAMP"},
+    {"name": "event_type", "dataType": "STRING"},
+    {"name": "dispatch_id", "dataType": "STRING"},
+    {"name": "order_id", "dataType": "STRING"},
+    {"name": "vehicle_id", "dataType": "STRING"},
+    {"name": "status", "dataType": "STRING"},
+    {"name": "eta", "dataType": "TIMESTAMP"},
+]
+
+
+dag = build_ingest_dag(
+    dag_id="ingest_dispatch_logs_south",
+    queue_name="dispatch_logs_south",
+    table_fqn="warehouse.fact_dispatch_logs",
+    event_model=DispatchLogEvent,
+    columns=COLUMNS,
+    table_description="Dispatch logs fact table",
+    date_field="event_ts",
+)

--- a/dags/dispatch_logs_dags/ingest_dispatch_logs_west.py
+++ b/dags/dispatch_logs_dags/ingest_dispatch_logs_west.py
@@ -1,0 +1,40 @@
+"""Ingest dispatch log events from RabbitMQ to Iceberg for west region."""
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from dags.base_ingest import build_ingest_dag
+
+
+class DispatchLogEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    dispatch_id: str
+    order_id: str
+    vehicle_id: str
+    status: str
+    eta: datetime
+
+
+COLUMNS = [
+    {"name": "event_id", "dataType": "STRING"},
+    {"name": "event_ts", "dataType": "TIMESTAMP"},
+    {"name": "event_type", "dataType": "STRING"},
+    {"name": "dispatch_id", "dataType": "STRING"},
+    {"name": "order_id", "dataType": "STRING"},
+    {"name": "vehicle_id", "dataType": "STRING"},
+    {"name": "status", "dataType": "STRING"},
+    {"name": "eta", "dataType": "TIMESTAMP"},
+]
+
+
+dag = build_ingest_dag(
+    dag_id="ingest_dispatch_logs_west",
+    queue_name="dispatch_logs_west",
+    table_fqn="warehouse.fact_dispatch_logs",
+    event_model=DispatchLogEvent,
+    columns=COLUMNS,
+    table_description="Dispatch logs fact table",
+    date_field="event_ts",
+)


### PR DESCRIPTION
## Summary
- add DAGs for ingesting dispatch log events for the east, south and west regions using the generic ingest DAG factory
- update project TODO to reflect new DAG coverage

## Testing
- `python -m py_compile dags/dispatch_logs_dags/ingest_dispatch_logs_south.py dags/dispatch_logs_dags/ingest_dispatch_logs_east.py dags/dispatch_logs_dags/ingest_dispatch_logs_west.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f6276ec888330909e4c907d6419fe