### PR TITLE
Add inventory ingestion DAGs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -58,7 +58,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] `dim_vehicle`
   * [x] `dim_product`
   * [x] `dim_route`
-* [ ] Partitioning strategy: use `event_date` for all `fact_` tables
+* [x] Partitioning strategy: use `event_date` for all `fact_` tables
 * [ ] Create Iceberg DDLs for DuckDB queries
   * [x] `fact_orders`
   * [x] `fact_returns`
@@ -92,7 +92,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
     * [x] `ingest_dispatch_logs_south.py` → from RabbitMQ to Iceberg
     * [x] `ingest_dispatch_logs_east.py` → from RabbitMQ to Iceberg
     * [x] `ingest_dispatch_logs_west.py` → from RabbitMQ to Iceberg
-    * [ ] `ingest_<event>_<region>.py` → from RabbitMQ to Iceberg
+    * [x] `ingest_inventory_<region>.py` → from RabbitMQ to Iceberg
   * [ ] `stg_<entity>.py` → transform raw to staging (via dbt)
   * [ ] `fact_<entity>.py` → load final fact tables
 * [ ] ML DAGs:

--- a/dags/inventory_dags/ingest_inventory_east.py
+++ b/dags/inventory_dags/ingest_inventory_east.py
@@ -1,0 +1,38 @@
+"""Ingest inventory movement events from RabbitMQ to Iceberg for east region."""
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from dags.base_ingest import build_ingest_dag
+
+
+class InventoryEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    movement_id: str
+    product_id: str
+    delta_qty: int
+    source_type: str
+
+
+COLUMNS = [
+    {"name": "event_id", "dataType": "STRING"},
+    {"name": "event_ts", "dataType": "TIMESTAMP"},
+    {"name": "event_type", "dataType": "STRING"},
+    {"name": "movement_id", "dataType": "STRING"},
+    {"name": "product_id", "dataType": "STRING"},
+    {"name": "delta_qty", "dataType": "INT"},
+    {"name": "source_type", "dataType": "STRING"},
+]
+
+
+dag = build_ingest_dag(
+    dag_id="ingest_inventory_east",
+    queue_name="inventory_east",
+    table_fqn="warehouse.fact_inventory_movements",
+    event_model=InventoryEvent,
+    columns=COLUMNS,
+    table_description="Inventory movements fact table",
+    date_field="event_ts",
+)

--- a/dags/inventory_dags/ingest_inventory_north.py
+++ b/dags/inventory_dags/ingest_inventory_north.py
@@ -1,0 +1,38 @@
+"""Ingest inventory movement events from RabbitMQ to Iceberg for north region."""
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from dags.base_ingest import build_ingest_dag
+
+
+class InventoryEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    movement_id: str
+    product_id: str
+    delta_qty: int
+    source_type: str
+
+
+COLUMNS = [
+    {"name": "event_id", "dataType": "STRING"},
+    {"name": "event_ts", "dataType": "TIMESTAMP"},
+    {"name": "event_type", "dataType": "STRING"},
+    {"name": "movement_id", "dataType": "STRING"},
+    {"name": "product_id", "dataType": "STRING"},
+    {"name": "delta_qty", "dataType": "INT"},
+    {"name": "source_type", "dataType": "STRING"},
+]
+
+
+dag = build_ingest_dag(
+    dag_id="ingest_inventory_north",
+    queue_name="inventory_north",
+    table_fqn="warehouse.fact_inventory_movements",
+    event_model=InventoryEvent,
+    columns=COLUMNS,
+    table_description="Inventory movements fact table",
+    date_field="event_ts",
+)

--- a/dags/inventory_dags/ingest_inventory_south.py
+++ b/dags/inventory_dags/ingest_inventory_south.py
@@ -1,0 +1,38 @@
+"""Ingest inventory movement events from RabbitMQ to Iceberg for south region."""
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from dags.base_ingest import build_ingest_dag
+
+
+class InventoryEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    movement_id: str
+    product_id: str
+    delta_qty: int
+    source_type: str
+
+
+COLUMNS = [
+    {"name": "event_id", "dataType": "STRING"},
+    {"name": "event_ts", "dataType": "TIMESTAMP"},
+    {"name": "event_type", "dataType": "STRING"},
+    {"name": "movement_id", "dataType": "STRING"},
+    {"name": "product_id", "dataType": "STRING"},
+    {"name": "delta_qty", "dataType": "INT"},
+    {"name": "source_type", "dataType": "STRING"},
+]
+
+
+dag = build_ingest_dag(
+    dag_id="ingest_inventory_south",
+    queue_name="inventory_south",
+    table_fqn="warehouse.fact_inventory_movements",
+    event_model=InventoryEvent,
+    columns=COLUMNS,
+    table_description="Inventory movements fact table",
+    date_field="event_ts",
+)

--- a/dags/inventory_dags/ingest_inventory_west.py
+++ b/dags/inventory_dags/ingest_inventory_west.py
@@ -1,0 +1,38 @@
+"""Ingest inventory movement events from RabbitMQ to Iceberg for west region."""
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from dags.base_ingest import build_ingest_dag
+
+
+class InventoryEvent(BaseModel):
+    event_id: str
+    event_ts: datetime
+    event_type: str
+    movement_id: str
+    product_id: str
+    delta_qty: int
+    source_type: str
+
+
+COLUMNS = [
+    {"name": "event_id", "dataType": "STRING"},
+    {"name": "event_ts", "dataType": "TIMESTAMP"},
+    {"name": "event_type", "dataType": "STRING"},
+    {"name": "movement_id", "dataType": "STRING"},
+    {"name": "product_id", "dataType": "STRING"},
+    {"name": "delta_qty", "dataType": "INT"},
+    {"name": "source_type", "dataType": "STRING"},
+]
+
+
+dag = build_ingest_dag(
+    dag_id="ingest_inventory_west",
+    queue_name="inventory_west",
+    table_fqn="warehouse.fact_inventory_movements",
+    event_model=InventoryEvent,
+    columns=COLUMNS,
+    table_description="Inventory movements fact table",
+    date_field="event_ts",
+)


### PR DESCRIPTION
## Summary
- add Airflow ingestion DAGs for inventory movement events in all regions
- mark inventory DAG and partitioning strategy as complete in TODO

## Testing
- `python -m py_compile dags/inventory_dags/ingest_inventory_*.py`


------
https://chatgpt.com/codex/tasks/task_e_688f639ab8f88330a49576870f0ca4e7