### PR TITLE
Add dbt model for dispatch logs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,6 +71,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
 * [ ] Create YAML specs for dbt models
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
+  * [x] `fact_dispatch_logs`
 
 ---
 

--- a/models/dbt/dispatch_logs/docs.md
+++ b/models/dbt/dispatch_logs/docs.md
@@ -1,0 +1,3 @@
+{% docs fact_dispatch_logs %}
+The `fact_dispatch_logs` model consolidates dispatch log events into an analytics-ready fact table. Each row captures a dispatch event, including vehicle assignment, status updates, and estimated arrival times. Records are partitioned by `event_date` for efficient querying.
+{% enddocs %}

--- a/models/dbt/dispatch_logs/fact_dispatch_logs.sql
+++ b/models/dbt/dispatch_logs/fact_dispatch_logs.sql
@@ -1,0 +1,20 @@
+{{ config(materialized='incremental', unique_key='dispatch_id') }}
+
+with source as (
+    select * from {{ source('dispatch_logs', 'raw_dispatch_logs') }}
+)
+
+select
+    event_id,
+    event_ts,
+    event_type,
+    dispatch_id,
+    order_id,
+    vehicle_id,
+    status,
+    eta,
+    cast(event_ts as date) as event_date
+from source
+{% if is_incremental() %}
+where event_ts > (select max(event_ts) from {{ this }})
+{% endif %}

--- a/models/dbt/dispatch_logs/schema.yml
+++ b/models/dbt/dispatch_logs/schema.yml
@@ -1,0 +1,27 @@
+version: 2
+
+sources:
+  - name: dispatch_logs
+    tables:
+      - name: raw_dispatch_logs
+        description: "Raw dispatch log events ingested from RabbitMQ."
+
+models:
+  - name: fact_dispatch_logs
+    description: "{{ doc('fact_dispatch_logs') }}"
+    columns:
+      - name: dispatch_id
+        description: "Unique dispatch identifier"
+        tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: "Associated order identifier"
+      - name: vehicle_id
+        description: "Assigned vehicle identifier"
+      - name: status
+        description: "Current dispatch status"
+      - name: eta
+        description: "Estimated time of arrival"
+      - name: event_date
+        description: "Partition column derived from event_ts"


### PR DESCRIPTION
## Summary
- add dbt model, schema, and documentation for `fact_dispatch_logs`
- check off TODO for dispatch log dbt YAML spec

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f64a78a148330bcc56a0e11da1157