### PR TITLE
Add DDLs for remaining warehouse tables

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,20 +54,34 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
   * [x] `fact_dispatch_logs`
+  * [x] `fact_vehicle_routes`
+  * [x] `fact_order_errors`
+  * [x] `fact_forecast_demand`
+  * [x] `fact_stockout_risks`
   * [x] `dim_warehouse`
   * [x] `dim_vehicle`
   * [x] `dim_product`
   * [x] `dim_route`
+  * [x] `dim_employee`
+  * [x] `dim_date`
+  * [x] `dim_error_code`
 * [x] Partitioning strategy: use `event_date` for all `fact_` tables
 * [ ] Create Iceberg DDLs for DuckDB queries
   * [x] `fact_orders`
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
   * [x] `fact_dispatch_logs`
+  * [x] `fact_vehicle_routes`
+  * [x] `fact_order_errors`
+  * [x] `fact_forecast_demand`
+  * [x] `fact_stockout_risks`
   * [x] `dim_warehouse`
   * [x] `dim_vehicle`
   * [x] `dim_product`
   * [x] `dim_route`
+  * [x] `dim_employee`
+  * [x] `dim_date`
+  * [x] `dim_error_code`
 * [ ] Create YAML specs for dbt models
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`

--- a/models/sql/dim_date.sql
+++ b/models/sql/dim_date.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS iceberg.dim_date (
+    date_id DATE,
+    day INT,
+    week INT,
+    month INT,
+    quarter INT,
+    year INT,
+    event_date DATE
+)
+USING iceberg
+PARTITIONED BY (event_date);

--- a/models/sql/dim_employee.sql
+++ b/models/sql/dim_employee.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS iceberg.dim_employee (
+    employee_id STRING,
+    role STRING,
+    assigned_warehouse STRING,
+    shift_hours INT,
+    event_date DATE
+)
+USING iceberg
+PARTITIONED BY (event_date);

--- a/models/sql/dim_error_code.sql
+++ b/models/sql/dim_error_code.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS iceberg.dim_error_code (
+    error_code STRING,
+    description STRING,
+    severity_level STRING,
+    event_date DATE
+)
+USING iceberg
+PARTITIONED BY (event_date);

--- a/models/sql/fact_forecast_demand.sql
+++ b/models/sql/fact_forecast_demand.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS iceberg.fact_forecast_demand (
+    event_id STRING,
+    event_ts TIMESTAMP,
+    event_type STRING,
+    product_id STRING,
+    region STRING,
+    forecast_ts TIMESTAMP,
+    forecast_qty INT,
+    event_date DATE
+)
+USING iceberg
+PARTITIONED BY (event_date);

--- a/models/sql/fact_order_errors.sql
+++ b/models/sql/fact_order_errors.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS iceberg.fact_order_errors (
+    event_id STRING,
+    event_ts TIMESTAMP,
+    event_type STRING,
+    error_id STRING,
+    order_id STRING,
+    error_code STRING,
+    detected_ts TIMESTAMP,
+    event_date DATE
+)
+USING iceberg
+PARTITIONED BY (event_date);

--- a/models/sql/fact_stockout_risks.sql
+++ b/models/sql/fact_stockout_risks.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS iceberg.fact_stockout_risks (
+    event_id STRING,
+    event_ts TIMESTAMP,
+    event_type STRING,
+    product_id STRING,
+    risk_score DOUBLE,
+    predicted_date DATE,
+    confidence DOUBLE,
+    event_date DATE
+)
+USING iceberg
+PARTITIONED BY (event_date);

--- a/models/sql/fact_vehicle_routes.sql
+++ b/models/sql/fact_vehicle_routes.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS iceberg.fact_vehicle_routes (
+    event_id STRING,
+    event_ts TIMESTAMP,
+    event_type STRING,
+    vehicle_id STRING,
+    route_id STRING,
+    assigned_ts TIMESTAMP,
+    location STRING,
+    event_date DATE
+)
+USING iceberg
+PARTITIONED BY (event_date);


### PR DESCRIPTION
## Summary
- define Iceberg DDLs for remaining fact tables: vehicle routes, order errors, forecast demand, stockout risks
- add DDLs for new dimensions: employee, date, and error code
- update TODO list to mark new schemas and DDLs as completed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f659af7e08330b89a77b02b18e28a