### PR TITLE
Add docker compose stack and Superset DuckDB configuration

### DIFF
--- a/.env
+++ b/.env
@@ -22,7 +22,7 @@ AIRFLOW__WEBSERVER__BASE_URL=http://localhost:8080
 
 # Superset
 SUPERSET_SECRET_KEY=CHANGE_ME
-SUPERSET_SQLALCHEMY_DATABASE_URI=sqlite:////app/superset.db
+SUPERSET_SQLALCHEMY_DATABASE_URI=duckdb:///data/warehouse.duckdb
 
 # DuckDB
 DUCKDB_PATH=/data/warehouse.duckdb

--- a/TODO.md
+++ b/TODO.md
@@ -6,16 +6,16 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
 
 ## 🔧 Infrastructure Setup
 
-* [ ] Create `docker-compose.yml` for full stack:
+* [x] Create `docker-compose.yml` for full stack:
 
-  * [ ] MinIO (Iceberg storage backend)
-  * [ ] Airflow (DAG orchestration)
-  * [ ] OpenMetadata (metadata layer)
-  * [ ] Superset (BI dashboarding)
-  * [ ] RabbitMQ (ingestion messaging)
-  * [ ] DuckDB (analytics engine)
+  * [x] MinIO (Iceberg storage backend)
+  * [x] Airflow (DAG orchestration)
+  * [x] OpenMetadata (metadata layer)
+  * [x] Superset (BI dashboarding)
+  * [x] RabbitMQ (ingestion messaging)
+  * [x] DuckDB (analytics engine)
 * [x] Create `.env` file for all services
-* [ ] Provision shared network and volumes for persistence
+* [x] Provision shared network and volumes for persistence
 
 ---
 
@@ -131,8 +131,8 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
 
 ## 📊 Superset Integration
 
-* [ ] Add Superset service to Docker Compose
-* [ ] Connect Superset to DuckDB SQL Engine
+* [x] Add Superset service to Docker Compose
+* [x] Connect Superset to DuckDB SQL Engine
 * [ ] Create starter dashboard for:
 
   * [ ] `fact_orders`, `fact_returns`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,98 @@
+version: "3.9"
+
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    ports:
+      - "${RABBITMQ_PORT}:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    networks:
+      - mesh
+
+  minio:
+    image: minio/minio:latest
+    container_name: minio
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    volumes:
+      - minio_data:/data
+    networks:
+      - mesh
+
+  airflow:
+    image: apache/airflow:2.8.1
+    container_name: airflow
+    env_file: .env
+    environment:
+      AIRFLOW__CORE__EXECUTOR: ${AIRFLOW__CORE__EXECUTOR}
+      AIRFLOW__CORE__FERNET_KEY: ${AIRFLOW__CORE__FERNET_KEY}
+      AIRFLOW__WEBSERVER__BASE_URL: ${AIRFLOW__WEBSERVER__BASE_URL}
+    volumes:
+      - ./dags:/opt/airflow/dags
+      - airflow_data:/opt/airflow
+    ports:
+      - "8080:8080"
+    depends_on:
+      - rabbitmq
+      - minio
+    networks:
+      - mesh
+
+  openmetadata:
+    image: openmetadata/server:1.2.2
+    container_name: openmetadata
+    ports:
+      - "8585:8585"
+    environment:
+      OPENMETADATA_SERVER_CONFIG: /openmetadata/config/docker.yaml
+    depends_on:
+      - minio
+    networks:
+      - mesh
+
+  duckdb:
+    image: ghcr.io/duckdb/duckdb:latest
+    container_name: duckdb
+    command: ["tail", "-f", "/dev/null"]
+    volumes:
+      - duckdb_data:/data
+    networks:
+      - mesh
+
+  superset:
+    image: apache/superset:latest
+    container_name: superset
+    env_file: .env
+    environment:
+      SUPERSET_SECRET_KEY: ${SUPERSET_SECRET_KEY}
+      SUPERSET_SQLALCHEMY_DATABASE_URI: ${SUPERSET_SQLALCHEMY_DATABASE_URI}
+    volumes:
+      - superset_data:/app/superset_home
+      - duckdb_data:/data
+    ports:
+      - "8088:8088"
+    depends_on:
+      - duckdb
+    networks:
+      - mesh
+
+networks:
+  mesh:
+
+volumes:
+  rabbitmq_data:
+  minio_data:
+  airflow_data:
+  superset_data:
+  duckdb_data:


### PR DESCRIPTION
## Summary
- add docker-compose stack for MinIO, Airflow, OpenMetadata, Superset, RabbitMQ, and DuckDB
- wire Superset to DuckDB via environment variables
- check off completed infrastructure tasks in TODO

## Testing
- `pytest`
- `python - <<'PY' import yaml; yaml.safe_load(open('docker-compose.yml')); print('OK') PY`

------
https://chatgpt.com/codex/tasks/task_e_688f6a008a948330a88aa757a193eff7