### PR TITLE
Add order error dbt model

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -86,6 +86,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
   * [x] `fact_dispatch_logs`
+  * [x] `fact_order_errors`
 
 ---
 

--- a/models/dbt/dbt_project.yml
+++ b/models/dbt/dbt_project.yml
@@ -4,5 +4,5 @@ config-version: 2
 
 profile: 'mesh_warehouse'
 
-model-paths: ['dispatch_logs', 'inventory', 'orders', 'returns']
+model-paths: ['dispatch_logs', 'inventory', 'orders', 'returns', 'order_errors']
 

--- a/models/dbt/order_errors/docs.md
+++ b/models/dbt/order_errors/docs.md
@@ -1,0 +1,3 @@
+{% docs fact_order_errors %}
+The `fact_order_errors` model captures operational and system issues encountered during order processing. Each record represents an error event and is partitioned by `event_date` for efficient analysis.
+{% enddocs %}

--- a/models/dbt/order_errors/fact_order_errors.sql
+++ b/models/dbt/order_errors/fact_order_errors.sql
@@ -1,0 +1,19 @@
+{{ config(materialized='incremental', unique_key='error_id') }}
+
+with source as (
+    select * from {{ source('order_errors', 'raw_order_errors') }}
+)
+
+select
+    event_id,
+    event_ts,
+    event_type,
+    error_id,
+    order_id,
+    error_code,
+    detected_ts,
+    cast(detected_ts as date) as event_date
+from source
+{% if is_incremental() %}
+where detected_ts > (select max(detected_ts) from {{ this }})
+{% endif %}

--- a/models/dbt/order_errors/schema.yml
+++ b/models/dbt/order_errors/schema.yml
@@ -1,0 +1,25 @@
+version: 2
+
+sources:
+  - name: order_errors
+    tables:
+      - name: raw_order_errors
+        description: "Raw order error events ingested from RabbitMQ."
+
+models:
+  - name: fact_order_errors
+    description: "{{ doc('fact_order_errors') }}"
+    columns:
+      - name: error_id
+        description: "Unique error identifier"
+        tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: "Associated order identifier"
+      - name: error_code
+        description: "Error code describing the issue"
+      - name: detected_ts
+        description: "Timestamp when the error was detected"
+      - name: event_date
+        description: "Partition column derived from detected_ts"


### PR DESCRIPTION
## Summary
- add dbt model for fact_order_errors with incremental loading
- document order error model and register in dbt project
- update TODO to mark order error YAML spec completed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f6b6ec6848330b006468ca3903e19