### PR TITLE
Add returns staging and fact DAGs with dbt models

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -87,6 +87,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] `fact_inventory_movements`
   * [x] `fact_dispatch_logs`
   * [x] `fact_order_errors`
+  * [x] `stg_returns`
 
 ---
 
@@ -111,8 +112,10 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
     * [x] `ingest_inventory_<region>.py` → from RabbitMQ to Iceberg
   * [ ] `stg_<entity>.py` → transform raw to staging (via dbt)
     * [x] `stg_orders.py`
+    * [x] `stg_returns.py`
   * [ ] `fact_<entity>.py` → load final fact tables
     * [x] `fact_orders.py`
+    * [x] `fact_returns.py`
 * [x] ML DAGs:
 
   * [x] `forecast_demand.py`

--- a/dags/returns_dags/fact_returns.py
+++ b/dags/returns_dags/fact_returns.py
@@ -1,0 +1,22 @@
+"""Airflow DAG to run the fact_returns dbt model."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
+
+with DAG(
+    dag_id="fact_returns",
+    schedule_interval="@daily",
+    start_date=days_ago(1),
+    catchup=False,
+    tags=["returns", "fact"],
+) as dag:
+    BashOperator(
+        task_id="dbt_run_fact_returns",
+        bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models fact_returns",
+    )

--- a/dags/returns_dags/stg_returns.py
+++ b/dags/returns_dags/stg_returns.py
@@ -1,0 +1,22 @@
+"""Airflow DAG to run the stg_returns dbt model."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
+
+with DAG(
+    dag_id="stg_returns",
+    schedule_interval="@daily",
+    start_date=days_ago(1),
+    catchup=False,
+    tags=["returns", "staging"],
+) as dag:
+    BashOperator(
+        task_id="dbt_run_stg_returns",
+        bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models stg_returns",
+    )

--- a/models/dbt/returns/docs.md
+++ b/models/dbt/returns/docs.md
@@ -1,3 +1,7 @@
 {% docs fact_returns %}
 The `fact_returns` model curates return events into an analytics-ready fact table. Each row represents a returned order event and is partitioned by `event_date` for efficient querying.
 {% enddocs %}
+
+{% docs stg_returns %}
+The `stg_returns` model normalizes raw return events and computes the `event_date` partition field used by downstream models.
+{% enddocs %}

--- a/models/dbt/returns/fact_returns.sql
+++ b/models/dbt/returns/fact_returns.sql
@@ -1,9 +1,5 @@
 {{ config(materialized='incremental', unique_key='return_id') }}
 
-with source as (
-    select * from {{ source('returns', 'raw_returns') }}
-)
-
 select
     event_id,
     event_ts,
@@ -12,8 +8,9 @@ select
     order_id,
     return_ts,
     reason_code,
-    cast(return_ts as date) as event_date
-from source
+    event_date
+from {{ ref('stg_returns') }}
 {% if is_incremental() %}
 where return_ts > (select max(return_ts) from {{ this }})
 {% endif %}
+

--- a/models/dbt/returns/schema.yml
+++ b/models/dbt/returns/schema.yml
@@ -7,6 +7,21 @@ sources:
         description: "Raw returns ingested from RabbitMQ."
 
 models:
+  - name: stg_returns
+    description: "{{ doc('stg_returns') }}"
+    columns:
+      - name: return_id
+        description: "Return identifier"
+        tests:
+          - not_null
+      - name: order_id
+        description: "Associated order identifier"
+      - name: return_ts
+        description: "Timestamp when the return occurred"
+      - name: reason_code
+        description: "Return reason code"
+      - name: event_date
+        description: "Partition column derived from return_ts"
   - name: fact_returns
     description: "{{ doc('fact_returns') }}"
     columns:

--- a/models/dbt/returns/stg_returns.sql
+++ b/models/dbt/returns/stg_returns.sql
@@ -1,0 +1,17 @@
+{{ config(materialized='view') }}
+
+with source as (
+    select * from {{ source('returns', 'raw_returns') }}
+)
+
+select
+    event_id,
+    event_ts,
+    event_type,
+    return_id,
+    order_id,
+    return_ts,
+    reason_code,
+    cast(return_ts as date) as event_date
+from source
+


### PR DESCRIPTION
## Summary
- add `stg_returns` dbt model and Airflow DAG
- add `fact_returns` dbt model and Airflow DAG
- document returns models and update TODO progress

## Testing
- `pytest`
- `python -m py_compile dags/returns_dags/stg_returns.py dags/returns_dags/fact_returns.py`
- `dbt ls --project-dir models/dbt --profiles-dir models/dbt --select stg_returns` *(fails: Documentation for 'model.mesh_warehouse.fact_inventory_movements' depends on doc 'fact_inventory_movements' which was not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f6c5d325483309e0ecd463d47c56f