### PR TITLE
Add order errors fact DAG

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -118,7 +118,8 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
     * [x] `fact_returns.py`
     * [x] `fact_inventory_movements.py`
     * [x] `fact_dispatch_logs.py`
-* [x] ML DAGs:
+    * [x] `fact_order_errors.py`
+  * [x] ML DAGs:
 
   * [x] `forecast_demand.py`
   * [x] `predict_stockout_risk.py`

--- a/dags/order_errors_dags/fact_order_errors.py
+++ b/dags/order_errors_dags/fact_order_errors.py
@@ -1,0 +1,22 @@
+"""Airflow DAG to run the fact_order_errors dbt model."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
+
+with DAG(
+    dag_id="fact_order_errors",
+    schedule_interval="@daily",
+    start_date=days_ago(1),
+    catchup=False,
+    tags=["order_errors", "fact"],
+) as dag:
+    BashOperator(
+        task_id="dbt_run_fact_order_errors",
+        bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models fact_order_errors",
+    )


### PR DESCRIPTION
## Summary
- add Airflow DAG to build fact_order_errors with dbt
- track DAG in project TODO list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f7051211883308562182ad1c7ad81