### PR TITLE
Add staging dispatch logs model and DAG

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -88,6 +88,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] `fact_dispatch_logs`
   * [x] `fact_order_errors`
   * [x] `stg_returns`
+  * [x] `stg_dispatch_logs`
 
 ---
 
@@ -110,9 +111,10 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
     * [x] `ingest_dispatch_logs_east.py` → from RabbitMQ to Iceberg
     * [x] `ingest_dispatch_logs_west.py` → from RabbitMQ to Iceberg
     * [x] `ingest_inventory_<region>.py` → from RabbitMQ to Iceberg
-  * [ ] `stg_<entity>.py` → transform raw to staging (via dbt)
-    * [x] `stg_orders.py`
-    * [x] `stg_returns.py`
+    * [ ] `stg_<entity>.py` → transform raw to staging (via dbt)
+      * [x] `stg_orders.py`
+      * [x] `stg_returns.py`
+      * [x] `stg_dispatch_logs.py`
   * [ ] `fact_<entity>.py` → load final fact tables
     * [x] `fact_orders.py`
     * [x] `fact_returns.py`

--- a/dags/dispatch_logs_dags/stg_dispatch_logs.py
+++ b/dags/dispatch_logs_dags/stg_dispatch_logs.py
@@ -1,0 +1,22 @@
+"""Airflow DAG to run the stg_dispatch_logs dbt model."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
+
+with DAG(
+    dag_id="stg_dispatch_logs",
+    schedule_interval="@daily",
+    start_date=days_ago(1),
+    catchup=False,
+    tags=["dispatch_logs", "staging"],
+) as dag:
+    BashOperator(
+        task_id="dbt_run_stg_dispatch_logs",
+        bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models stg_dispatch_logs",
+    )

--- a/models/dbt/dispatch_logs/docs.md
+++ b/models/dbt/dispatch_logs/docs.md
@@ -1,3 +1,7 @@
 {% docs fact_dispatch_logs %}
 The `fact_dispatch_logs` model consolidates dispatch log events into an analytics-ready fact table. Each row captures a dispatch event, including vehicle assignment, status updates, and estimated arrival times. Records are partitioned by `event_date` for efficient querying.
 {% enddocs %}
+
+{% docs stg_dispatch_logs %}
+The `stg_dispatch_logs` model normalizes raw dispatch log events and derives the `event_date` partition field used by downstream models.
+{% enddocs %}

--- a/models/dbt/dispatch_logs/schema.yml
+++ b/models/dbt/dispatch_logs/schema.yml
@@ -7,6 +7,24 @@ sources:
         description: "Raw dispatch log events ingested from RabbitMQ."
 
 models:
+  - name: stg_dispatch_logs
+    description: "{{ doc('stg_dispatch_logs') }}"
+    columns:
+      - name: dispatch_id
+        description: "Unique dispatch identifier"
+        tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: "Associated order identifier"
+      - name: vehicle_id
+        description: "Assigned vehicle identifier"
+      - name: status
+        description: "Current dispatch status"
+      - name: eta
+        description: "Estimated time of arrival"
+      - name: event_date
+        description: "Partition column derived from event_ts"
   - name: fact_dispatch_logs
     description: "{{ doc('fact_dispatch_logs') }}"
     columns:

--- a/models/dbt/dispatch_logs/stg_dispatch_logs.sql
+++ b/models/dbt/dispatch_logs/stg_dispatch_logs.sql
@@ -1,0 +1,17 @@
+{{ config(materialized='view') }}
+
+with source as (
+    select * from {{ source('dispatch_logs', 'raw_dispatch_logs') }}
+)
+
+select
+    event_id,
+    event_ts,
+    event_type,
+    dispatch_id,
+    order_id,
+    vehicle_id,
+    status,
+    eta,
+    cast(event_ts as date) as event_date
+from source


### PR DESCRIPTION
## Summary
- add stg_dispatch_logs dbt model and schema specs
- run stg_dispatch_logs via new Airflow DAG
- update TODO with dispatch log staging tasks

## Testing
- `python -m py_compile dags/dispatch_logs_dags/stg_dispatch_logs.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f717cfafc83309824cb611aeb8ffe