### PR TITLE
Add inventory staging model and DAG

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -89,6 +89,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] `fact_order_errors`
   * [x] `stg_returns`
   * [x] `stg_dispatch_logs`
+  * [x] `stg_inventory_movements`
 
 ---
 
@@ -111,10 +112,11 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
     * [x] `ingest_dispatch_logs_east.py` → from RabbitMQ to Iceberg
     * [x] `ingest_dispatch_logs_west.py` → from RabbitMQ to Iceberg
     * [x] `ingest_inventory_<region>.py` → from RabbitMQ to Iceberg
-    * [ ] `stg_<entity>.py` → transform raw to staging (via dbt)
+  * [ ] `stg_<entity>.py` → transform raw to staging (via dbt)
       * [x] `stg_orders.py`
       * [x] `stg_returns.py`
       * [x] `stg_dispatch_logs.py`
+      * [x] `stg_inventory_movements.py`
   * [ ] `fact_<entity>.py` → load final fact tables
     * [x] `fact_orders.py`
     * [x] `fact_returns.py`

--- a/dags/inventory_dags/stg_inventory_movements.py
+++ b/dags/inventory_dags/stg_inventory_movements.py
@@ -1,0 +1,22 @@
+"""Airflow DAG to run the stg_inventory_movements dbt model."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
+
+with DAG(
+    dag_id="stg_inventory_movements",
+    schedule_interval="@daily",
+    start_date=days_ago(1),
+    catchup=False,
+    tags=["inventory", "staging"],
+) as dag:
+    BashOperator(
+        task_id="dbt_run_stg_inventory_movements",
+        bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models stg_inventory_movements",
+    )

--- a/models/dbt/inventory/docs.md
+++ b/models/dbt/inventory/docs.md
@@ -1,5 +1,7 @@
-# Inventory Models
+{% docs stg_inventory_movements %}
+The `stg_inventory_movements` model normalizes raw inventory movement events and computes the `event_date` partition field used by downstream models.
+{% enddocs %}
 
-## fact_inventory_movements
-
+{% docs fact_inventory_movements %}
 Records changes to product inventory levels. Each row represents a single movement event captured from warehouse operations.
+{% enddocs %}

--- a/models/dbt/inventory/schema.yml
+++ b/models/dbt/inventory/schema.yml
@@ -7,6 +7,21 @@ sources:
         description: "Raw inventory movements ingested from RabbitMQ."
 
 models:
+  - name: stg_inventory_movements
+    description: "{{ doc('stg_inventory_movements') }}"
+    columns:
+      - name: movement_id
+        description: "Inventory movement identifier"
+        tests:
+          - not_null
+      - name: product_id
+        description: "Product identifier"
+      - name: delta_qty
+        description: "Quantity change"
+      - name: source_type
+        description: "Source of the inventory change"
+      - name: event_date
+        description: "Partition column derived from event_ts"
   - name: fact_inventory_movements
     description: "{{ doc('fact_inventory_movements') }}"
     columns:

--- a/models/dbt/inventory/stg_inventory_movements.sql
+++ b/models/dbt/inventory/stg_inventory_movements.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='view') }}
+
+with source as (
+    select * from {{ source('inventory', 'raw_inventory_movements') }}
+)
+
+select
+    event_id,
+    event_ts,
+    event_type,
+    movement_id,
+    product_id,
+    delta_qty,
+    source_type,
+    cast(event_ts as date) as event_date
+from source


### PR DESCRIPTION
## Summary
- add dbt staging model for inventory movements with documentation and schema updates
- create Airflow DAG to run the inventory staging model
- record new work items in TODO list

## Testing
- `python -m py_compile dags/inventory_dags/stg_inventory_movements.py`
- `cd models/dbt && dbt parse --profiles-dir .`


------
https://chatgpt.com/codex/tasks/task_e_688f72a12ff083308d9e42b871eef340