### PR TITLE
feat: add logging utility for order producers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -178,6 +178,8 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [ ] DAG syntax and dry-run
   * [ ] Iceberg schema compliance
 * [ ] Add logging to all generator and DAG processes
+  * [x] Introduce shared logger utility for producers
+  * [x] Apply logging to order event producers and stg_orders DAG
 * [ ] Implement unit test suite for DAG logic and data contracts
 
 ---

--- a/dags/orders_dags/stg_orders.py
+++ b/dags/orders_dags/stg_orders.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
+
+logger = logging.getLogger(__name__)
 
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
 
@@ -16,6 +19,7 @@ with DAG(
     catchup=False,
     tags=["orders", "staging"],
 ) as dag:
+    logger.info("Configuring stg_orders DAG")
     BashOperator(
         task_id="dbt_run_stg_orders",
         bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models stg_orders",

--- a/ingestion/producers/base_generator.py
+++ b/ingestion/producers/base_generator.py
@@ -8,6 +8,7 @@ deterministic given the same seed value.
 
 from __future__ import annotations
 
+import logging
 from random import Random
 from typing import Sequence, TypeVar
 
@@ -36,3 +37,25 @@ class BaseGenerator:
     def randint(self, a: int, b: int) -> int:
         """Return random integer ``N`` such that ``a <= N <= b``."""
         return self._rng.randint(a, b)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger configured to emit to stdout.
+
+    This helper centralizes logger configuration so that individual
+    generator scripts can obtain a ready-to-use logger without repeating
+    boilerplate setup.  If the logger for *name* has not been configured,
+    a :class:`~logging.StreamHandler` with a simple format is attached and
+    the level is set to ``INFO``.
+    """
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger

--- a/ingestion/producers/orders/produce_orders_east.py
+++ b/ingestion/producers/orders/produce_orders_east.py
@@ -17,7 +17,10 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("orders_order_created_east")
@@ -52,9 +55,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/orders/produce_orders_north.py
+++ b/ingestion/producers/orders/produce_orders_north.py
@@ -17,7 +17,10 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("orders_order_created")
@@ -52,9 +55,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/orders/produce_orders_south.py
+++ b/ingestion/producers/orders/produce_orders_south.py
@@ -17,7 +17,10 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("orders_order_created_south")
@@ -56,9 +59,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/orders/produce_orders_west.py
+++ b/ingestion/producers/orders/produce_orders_west.py
@@ -17,7 +17,10 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("orders_order_created_west")
@@ -52,9 +55,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:


### PR DESCRIPTION
## Summary
- add reusable logging helper for event generators
- apply structured logging to order producers and stg_orders DAG
- document progress on logging tasks in TODO

## Testing
- `python -m py_compile ingestion/producers/base_generator.py ingestion/producers/orders/produce_orders_north.py ingestion/producers/orders/produce_orders_south.py ingestion/producers/orders/produce_orders_east.py ingestion/producers/orders/produce_orders_west.py dags/orders_dags/stg_orders.py`


------
https://chatgpt.com/codex/tasks/task_e_688f73f235e08330be7faa411356687a