### PR TITLE
Add structured logging for returns pipeline

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -180,6 +180,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
 * [ ] Add logging to all generator and DAG processes
   * [x] Introduce shared logger utility for producers
   * [x] Apply logging to order event producers and stg_orders DAG
+  * [x] Apply logging to return event producers and stg_returns DAG
 * [ ] Implement unit test suite for DAG logic and data contracts
 
 ---

--- a/dags/returns_dags/stg_returns.py
+++ b/dags/returns_dags/stg_returns.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
 
+logger = logging.getLogger(__name__)
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
 
 with DAG(
@@ -16,6 +18,7 @@ with DAG(
     catchup=False,
     tags=["returns", "staging"],
 ) as dag:
+    logger.info("Configuring stg_returns DAG")
     BashOperator(
         task_id="dbt_run_stg_returns",
         bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models stg_returns",

--- a/ingestion/producers/returns/produce_returns_east.py
+++ b/ingestion/producers/returns/produce_returns_east.py
@@ -16,10 +16,11 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
 
 
 rng = BaseGenerator("returns_return_created_east")
+logger = get_logger(__name__)
 
 
 class ReturnEvent(BaseModel):
@@ -45,9 +46,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/returns/produce_returns_north.py
+++ b/ingestion/producers/returns/produce_returns_north.py
@@ -16,10 +16,11 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
 
 
 rng = BaseGenerator("returns_return_created_north")
+logger = get_logger(__name__)
 
 
 class ReturnEvent(BaseModel):
@@ -45,9 +46,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/returns/produce_returns_south.py
+++ b/ingestion/producers/returns/produce_returns_south.py
@@ -16,10 +16,11 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
 
 
 rng = BaseGenerator("returns_return_created_south")
+logger = get_logger(__name__)
 
 
 class ReturnEvent(BaseModel):
@@ -45,9 +46,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/returns/produce_returns_west.py
+++ b/ingestion/producers/returns/produce_returns_west.py
@@ -16,10 +16,11 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
 
 
 rng = BaseGenerator("returns_return_created_west")
+logger = get_logger(__name__)
 
 
 class ReturnEvent(BaseModel):
@@ -45,9 +46,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:


### PR DESCRIPTION
## Summary
- use shared logger in return event generators instead of print statements
- log configuration steps in stg_returns DAG
- track completed logging tasks in TODO

## Testing
- `python -m py_compile dags/returns_dags/stg_returns.py ingestion/producers/returns/produce_returns_east.py ingestion/producers/returns/produce_returns_north.py ingestion/producers/returns/produce_returns_south.py ingestion/producers/returns/produce_returns_west.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f7533153083308b7f1237e5920e5f