### PR TITLE
refactor: use logging for ingestion scripts

### DIFF
--- a/ingestion/producers/dispatch_logs/produce_dispatch_logs_east.py
+++ b/ingestion/producers/dispatch_logs/produce_dispatch_logs_east.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "east"
@@ -54,9 +56,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/dispatch_logs/produce_dispatch_logs_north.py
+++ b/ingestion/producers/dispatch_logs/produce_dispatch_logs_north.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "north"
@@ -54,9 +56,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/dispatch_logs/produce_dispatch_logs_south.py
+++ b/ingestion/producers/dispatch_logs/produce_dispatch_logs_south.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "south"
@@ -54,9 +56,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/dispatch_logs/produce_dispatch_logs_west.py
+++ b/ingestion/producers/dispatch_logs/produce_dispatch_logs_west.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "west"
@@ -54,9 +56,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/errors/produce_errors_east.py
+++ b/ingestion/producers/errors/produce_errors_east.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "east"
@@ -50,9 +52,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/errors/produce_errors_north.py
+++ b/ingestion/producers/errors/produce_errors_north.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "north"
@@ -50,9 +52,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/errors/produce_errors_south.py
+++ b/ingestion/producers/errors/produce_errors_south.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "south"
@@ -50,9 +52,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/errors/produce_errors_west.py
+++ b/ingestion/producers/errors/produce_errors_west.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "west"
@@ -50,9 +52,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/inventory/produce_inventory_east.py
+++ b/ingestion/producers/inventory/produce_inventory_east.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "east"
@@ -49,9 +51,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/inventory/produce_inventory_north.py
+++ b/ingestion/producers/inventory/produce_inventory_north.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "north"
@@ -49,9 +51,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/inventory/produce_inventory_south.py
+++ b/ingestion/producers/inventory/produce_inventory_south.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "south"
@@ -49,9 +51,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/inventory/produce_inventory_west.py
+++ b/ingestion/producers/inventory/produce_inventory_west.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "west"
@@ -49,9 +51,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/logistics_core/produce_delivery_sla.py
+++ b/ingestion/producers/logistics_core/produce_delivery_sla.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("logistics_delivery_sla")
@@ -58,9 +60,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/logistics_core/produce_route_updates.py
+++ b/ingestion/producers/logistics_core/produce_route_updates.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("logistics_route_update")
@@ -50,9 +52,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/logistics_core/produce_vehicle_tracking.py
+++ b/ingestion/producers/logistics_core/produce_vehicle_tracking.py
@@ -17,7 +17,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("logistics_vehicle_tracking")
@@ -55,9 +57,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/ml_insights/produce_demand_forecast.py
+++ b/ingestion/producers/ml_insights/produce_demand_forecast.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("ml_demand_forecast")
@@ -58,9 +60,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/ml_insights/produce_sla_risk.py
+++ b/ingestion/producers/ml_insights/produce_sla_risk.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("ml_sla_risk")
@@ -57,9 +59,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/ml_insights/produce_stockout_risk.py
+++ b/ingestion/producers/ml_insights/produce_stockout_risk.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("ml_stockout_risk")
@@ -58,9 +60,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/restocks/produce_restocks_east.py
+++ b/ingestion/producers/restocks/produce_restocks_east.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "east"
@@ -60,9 +62,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/restocks/produce_restocks_north.py
+++ b/ingestion/producers/restocks/produce_restocks_north.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "north"
@@ -60,9 +62,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/restocks/produce_restocks_south.py
+++ b/ingestion/producers/restocks/produce_restocks_south.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "south"
@@ -60,9 +62,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/restocks/produce_restocks_west.py
+++ b/ingestion/producers/restocks/produce_restocks_west.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 REGION = "west"
@@ -60,9 +62,9 @@ def publish_events(
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(

--- a/ingestion/producers/returns/produce_returns_east.py
+++ b/ingestion/producers/returns/produce_returns_east.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("returns_return_created_east")
@@ -45,9 +47,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/returns/produce_returns_north.py
+++ b/ingestion/producers/returns/produce_returns_north.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("returns_return_created_north")
@@ -45,9 +47,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/returns/produce_returns_south.py
+++ b/ingestion/producers/returns/produce_returns_south.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("returns_return_created_south")
@@ -45,9 +47,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:

--- a/ingestion/producers/returns/produce_returns_west.py
+++ b/ingestion/producers/returns/produce_returns_west.py
@@ -16,7 +16,9 @@ from pathlib import Path as _Path
 # Ensure parent directory (with base_generator) is on path when executed as a script
 sys.path.append(str(_Path(__file__).resolve().parents[1]))
 
-from base_generator import BaseGenerator
+from base_generator import BaseGenerator, get_logger
+
+logger = get_logger(__name__)
 
 
 rng = BaseGenerator("returns_return_created_west")
@@ -45,9 +47,9 @@ def publish_events(channel: pika.adapters.blocking_connection.BlockingChannel, q
         try:
             payload = event.json()
             channel.basic_publish(exchange="", routing_key=queue, body=payload)
-            print(payload)
+            logger.info(payload)
         except ValidationError as exc:
-            print(f"Validation failed: {exc}")
+            logger.error("Validation failed: %s", exc)
 
 
 def live_mode(channel: pika.adapters.blocking_connection.BlockingChannel, queue: str, interval: int) -> None:


### PR DESCRIPTION
## Summary
- replace all print statements in ingestion producers with a shared logger
- switch `start_generators.py` to use central logger for status messages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f75981dc483309bcb97aff5c7606e