### PR TITLE
Add logging to remaining staging DAGs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -181,6 +181,8 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] Introduce shared logger utility for producers
   * [x] Apply logging to order event producers and stg_orders DAG
   * [x] Apply logging to return event producers and stg_returns DAG
+  * [x] Apply logging to dispatch log DAGs
+  * [x] Apply logging to inventory DAGs
 * [ ] Implement unit test suite for DAG logic and data contracts
 
 ---

--- a/dags/dispatch_logs_dags/stg_dispatch_logs.py
+++ b/dags/dispatch_logs_dags/stg_dispatch_logs.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
 
+logger = logging.getLogger(__name__)
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
 
 with DAG(
@@ -16,6 +18,7 @@ with DAG(
     catchup=False,
     tags=["dispatch_logs", "staging"],
 ) as dag:
+    logger.info("Configuring stg_dispatch_logs DAG")
     BashOperator(
         task_id="dbt_run_stg_dispatch_logs",
         bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models stg_dispatch_logs",

--- a/dags/inventory_dags/stg_inventory_movements.py
+++ b/dags/inventory_dags/stg_inventory_movements.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
 
+logger = logging.getLogger(__name__)
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
 
 with DAG(
@@ -16,6 +18,7 @@ with DAG(
     catchup=False,
     tags=["inventory", "staging"],
 ) as dag:
+    logger.info("Configuring stg_inventory_movements DAG")
     BashOperator(
         task_id="dbt_run_stg_inventory_movements",
         bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models stg_inventory_movements",


### PR DESCRIPTION
## Summary
- log configuration steps for stg_dispatch_logs and stg_inventory_movements DAGs
- record completion of dispatch and inventory logging tasks in TODO

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f775723bc8330b77ba9411881632f