### PR TITLE
Add logging across Airflow DAGs

### DIFF
--- a/dags/dispatch_logs_dags/fact_dispatch_logs.py
+++ b/dags/dispatch_logs_dags/fact_dispatch_logs.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
+
+logger = logging.getLogger(__name__)
 
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
 
@@ -16,6 +19,7 @@ with DAG(
     catchup=False,
     tags=["dispatch_logs", "fact"],
 ) as dag:
+    logger.info("Configuring fact_dispatch_logs DAG")
     BashOperator(
         task_id="dbt_run_fact_dispatch_logs",
         bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models fact_dispatch_logs",

--- a/dags/dispatch_logs_dags/ingest_dispatch_logs_east.py
+++ b/dags/dispatch_logs_dags/ingest_dispatch_logs_east.py
@@ -1,9 +1,12 @@
 """Ingest dispatch log events from RabbitMQ to Iceberg for east region."""
 from datetime import datetime
+import logging
 
 from pydantic import BaseModel
 
 from dags.base_ingest import build_ingest_dag
+
+logger = logging.getLogger(__name__)
 
 
 class DispatchLogEvent(BaseModel):
@@ -38,3 +41,4 @@ dag = build_ingest_dag(
     table_description="Dispatch logs fact table",
     date_field="event_ts",
 )
+logger.info("Configured ingest_dispatch_logs_east DAG")

--- a/dags/dispatch_logs_dags/ingest_dispatch_logs_south.py
+++ b/dags/dispatch_logs_dags/ingest_dispatch_logs_south.py
@@ -1,9 +1,12 @@
 """Ingest dispatch log events from RabbitMQ to Iceberg for south region."""
 from datetime import datetime
+import logging
 
 from pydantic import BaseModel
 
 from dags.base_ingest import build_ingest_dag
+
+logger = logging.getLogger(__name__)
 
 
 class DispatchLogEvent(BaseModel):
@@ -38,3 +41,4 @@ dag = build_ingest_dag(
     table_description="Dispatch logs fact table",
     date_field="event_ts",
 )
+logger.info("Configured ingest_dispatch_logs_south DAG")

--- a/dags/dispatch_logs_dags/ingest_dispatch_logs_west.py
+++ b/dags/dispatch_logs_dags/ingest_dispatch_logs_west.py
@@ -1,9 +1,12 @@
 """Ingest dispatch log events from RabbitMQ to Iceberg for west region."""
 from datetime import datetime
+import logging
 
 from pydantic import BaseModel
 
 from dags.base_ingest import build_ingest_dag
+
+logger = logging.getLogger(__name__)
 
 
 class DispatchLogEvent(BaseModel):
@@ -38,3 +41,4 @@ dag = build_ingest_dag(
     table_description="Dispatch logs fact table",
     date_field="event_ts",
 )
+logger.info("Configured ingest_dispatch_logs_west DAG")

--- a/dags/inventory_dags/fact_inventory_movements.py
+++ b/dags/inventory_dags/fact_inventory_movements.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
+
+logger = logging.getLogger(__name__)
 
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
 
@@ -16,6 +19,7 @@ with DAG(
     catchup=False,
     tags=["inventory", "fact"],
 ) as dag:
+    logger.info("Configuring fact_inventory_movements DAG")
     BashOperator(
         task_id="dbt_run_fact_inventory_movements",
         bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models fact_inventory_movements",

--- a/dags/inventory_dags/ingest_inventory_east.py
+++ b/dags/inventory_dags/ingest_inventory_east.py
@@ -1,9 +1,12 @@
 """Ingest inventory movement events from RabbitMQ to Iceberg for east region."""
 from datetime import datetime
+import logging
 
 from pydantic import BaseModel
 
 from dags.base_ingest import build_ingest_dag
+
+logger = logging.getLogger(__name__)
 
 
 class InventoryEvent(BaseModel):
@@ -36,3 +39,4 @@ dag = build_ingest_dag(
     table_description="Inventory movements fact table",
     date_field="event_ts",
 )
+logger.info("Configured ingest_inventory_east DAG")

--- a/dags/inventory_dags/ingest_inventory_north.py
+++ b/dags/inventory_dags/ingest_inventory_north.py
@@ -1,9 +1,12 @@
 """Ingest inventory movement events from RabbitMQ to Iceberg for north region."""
 from datetime import datetime
+import logging
 
 from pydantic import BaseModel
 
 from dags.base_ingest import build_ingest_dag
+
+logger = logging.getLogger(__name__)
 
 
 class InventoryEvent(BaseModel):
@@ -36,3 +39,4 @@ dag = build_ingest_dag(
     table_description="Inventory movements fact table",
     date_field="event_ts",
 )
+logger.info("Configured ingest_inventory_north DAG")

--- a/dags/inventory_dags/ingest_inventory_south.py
+++ b/dags/inventory_dags/ingest_inventory_south.py
@@ -1,9 +1,12 @@
 """Ingest inventory movement events from RabbitMQ to Iceberg for south region."""
 from datetime import datetime
+import logging
 
 from pydantic import BaseModel
 
 from dags.base_ingest import build_ingest_dag
+
+logger = logging.getLogger(__name__)
 
 
 class InventoryEvent(BaseModel):
@@ -36,3 +39,4 @@ dag = build_ingest_dag(
     table_description="Inventory movements fact table",
     date_field="event_ts",
 )
+logger.info("Configured ingest_inventory_south DAG")

--- a/dags/inventory_dags/ingest_inventory_west.py
+++ b/dags/inventory_dags/ingest_inventory_west.py
@@ -1,9 +1,12 @@
 """Ingest inventory movement events from RabbitMQ to Iceberg for west region."""
 from datetime import datetime
+import logging
 
 from pydantic import BaseModel
 
 from dags.base_ingest import build_ingest_dag
+
+logger = logging.getLogger(__name__)
 
 
 class InventoryEvent(BaseModel):
@@ -36,3 +39,4 @@ dag = build_ingest_dag(
     table_description="Inventory movements fact table",
     date_field="event_ts",
 )
+logger.info("Configured ingest_inventory_west DAG")

--- a/dags/ml_dags/forecast_demand.py
+++ b/dags/ml_dags/forecast_demand.py
@@ -1,14 +1,18 @@
 """Airflow DAG to run the demand forecasting task."""
 from __future__ import annotations
 
+import logging
+
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 
+logger = logging.getLogger(__name__)
+
 
 def run_forecast() -> None:
     """Placeholder callable for demand forecasting logic."""
-    print("Executing demand forecast placeholder")
+    logger.info("Executing demand forecast placeholder")
 
 
 with DAG(
@@ -18,6 +22,7 @@ with DAG(
     catchup=False,
     tags=["ml", "forecast"],
 ) as dag:
+    logger.info("Configuring forecast_demand DAG")
     PythonOperator(
         task_id="run_demand_forecast",
         python_callable=run_forecast,

--- a/dags/ml_dags/predict_stockout_risk.py
+++ b/dags/ml_dags/predict_stockout_risk.py
@@ -1,14 +1,18 @@
 """Airflow DAG to predict stockout risks."""
 from __future__ import annotations
 
+import logging
+
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 
+logger = logging.getLogger(__name__)
+
 
 def predict_stockout() -> None:
     """Placeholder callable for stockout risk prediction."""
-    print("Executing stockout risk prediction placeholder")
+    logger.info("Executing stockout risk prediction placeholder")
 
 
 with DAG(
@@ -18,6 +22,7 @@ with DAG(
     catchup=False,
     tags=["ml", "risk"],
 ) as dag:
+    logger.info("Configuring predict_stockout_risk DAG")
     PythonOperator(
         task_id="run_stockout_risk_prediction",
         python_callable=predict_stockout,

--- a/dags/order_errors_dags/fact_order_errors.py
+++ b/dags/order_errors_dags/fact_order_errors.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
+
+logger = logging.getLogger(__name__)
 
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
 
@@ -16,6 +19,7 @@ with DAG(
     catchup=False,
     tags=["order_errors", "fact"],
 ) as dag:
+    logger.info("Configuring fact_order_errors DAG")
     BashOperator(
         task_id="dbt_run_fact_order_errors",
         bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models fact_order_errors",

--- a/dags/orders_dags/fact_orders.py
+++ b/dags/orders_dags/fact_orders.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
+
+logger = logging.getLogger(__name__)
 
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
 
@@ -16,6 +19,7 @@ with DAG(
     catchup=False,
     tags=["orders", "fact"],
 ) as dag:
+    logger.info("Configuring fact_orders DAG")
     BashOperator(
         task_id="dbt_run_fact_orders",
         bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models fact_orders",

--- a/dags/region_dags/stg_region.py
+++ b/dags/region_dags/stg_region.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
 from airflow.utils.helpers import chain
 
+logger = logging.getLogger(__name__)
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
 STG_REGION_DIR = DBT_PROJECT_DIR / "stg_region"
 MODEL_NAMES = sorted(p.stem for p in STG_REGION_DIR.glob("*.sql"))
@@ -29,6 +31,7 @@ with DAG(
     catchup=False,
     tags=["region", "staging"],
 ) as dag:
+    logger.info("Configuring stg_region DAG with models: %s", MODEL_NAMES)
     tasks = [make_dbt_task(name) for name in MODEL_NAMES]
     if tasks:
         chain(*tasks)

--- a/dags/returns_dags/fact_returns.py
+++ b/dags/returns_dags/fact_returns.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+import logging
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.utils.dates import days_ago
+
+logger = logging.getLogger(__name__)
 
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
 
@@ -16,6 +19,7 @@ with DAG(
     catchup=False,
     tags=["returns", "fact"],
 ) as dag:
+    logger.info("Configuring fact_returns DAG")
     BashOperator(
         task_id="dbt_run_fact_returns",
         bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models fact_returns",

--- a/dags/returns_dags/ingest_returns_east.py
+++ b/dags/returns_dags/ingest_returns_east.py
@@ -1,7 +1,10 @@
 from datetime import datetime
+import logging
 from pydantic import BaseModel
 
 from dags.base_ingest import build_ingest_dag
+
+logger = logging.getLogger(__name__)
 
 
 class ReturnEvent(BaseModel):
@@ -34,3 +37,4 @@ dag = build_ingest_dag(
     table_description="Returns fact table",
     date_field="return_ts",
 )
+logger.info("Configured ingest_returns_east DAG")

--- a/dags/returns_dags/ingest_returns_north.py
+++ b/dags/returns_dags/ingest_returns_north.py
@@ -1,7 +1,10 @@
 from datetime import datetime
+import logging
 from pydantic import BaseModel
 
 from dags.base_ingest import build_ingest_dag
+
+logger = logging.getLogger(__name__)
 
 
 class ReturnEvent(BaseModel):
@@ -33,3 +36,4 @@ dag = build_ingest_dag(
     table_description="Returns fact table",
     date_field="return_ts",
 )
+logger.info("Configured ingest_returns_north DAG")

--- a/dags/returns_dags/ingest_returns_south.py
+++ b/dags/returns_dags/ingest_returns_south.py
@@ -1,7 +1,10 @@
 from datetime import datetime
+import logging
 from pydantic import BaseModel
 
 from dags.base_ingest import build_ingest_dag
+
+logger = logging.getLogger(__name__)
 
 
 class ReturnEvent(BaseModel):
@@ -34,3 +37,4 @@ dag = build_ingest_dag(
     table_description="Returns fact table",
     date_field="return_ts",
 )
+logger.info("Configured ingest_returns_south DAG")

--- a/dags/returns_dags/ingest_returns_west.py
+++ b/dags/returns_dags/ingest_returns_west.py
@@ -1,7 +1,10 @@
 from datetime import datetime
+import logging
 from pydantic import BaseModel
 
 from dags.base_ingest import build_ingest_dag
+
+logger = logging.getLogger(__name__)
 
 
 class ReturnEvent(BaseModel):
@@ -34,3 +37,4 @@ dag = build_ingest_dag(
     table_description="Returns fact table",
     date_field="return_ts",
 )
+logger.info("Configured ingest_returns_west DAG")


### PR DESCRIPTION
## Summary
- add module-level loggers and info messages for all DAGs
- replace print statements in ML DAGs with structured logging
- log DAG construction in ingest DAG factory and wrappers

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f78a3bc94833089e6629a49fc772e