### PR TITLE
test: verify Iceberg table schemas

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -172,16 +172,16 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
 
 ## 🧪 Testing & Validation
 
-  * [ ] Add CI test for:
+  * [x] Add CI test for:
     * [x] Data generator schema match
     * [x] DAG syntax and dry-run
-    * [ ] Iceberg schema compliance
-* [ ] Add logging to all generator and DAG processes
-  * [x] Introduce shared logger utility for producers
-  * [x] Apply logging to order event producers and stg_orders DAG
-  * [x] Apply logging to return event producers and stg_returns DAG
-  * [x] Apply logging to dispatch log DAGs
-  * [x] Apply logging to inventory DAGs
+    * [x] Iceberg schema compliance
+  * [ ] Add logging to all generator and DAG processes
+    * [x] Introduce shared logger utility for producers
+    * [x] Apply logging to order event producers and stg_orders DAG
+    * [x] Apply logging to return event producers and stg_returns DAG
+    * [x] Apply logging to dispatch log DAGs
+    * [x] Apply logging to inventory DAGs
 * [ ] Implement unit test suite for DAG logic and data contracts
 
 ---

--- a/tests/test_iceberg_schema.py
+++ b/tests/test_iceberg_schema.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pytest
+
+SQL_DIR = Path(__file__).resolve().parents[1] / "models" / "sql"
+
+
+@pytest.mark.parametrize("sql_file", list(SQL_DIR.glob("*.sql")))
+def test_iceberg_ddl_compliance(sql_file: Path) -> None:
+    """Ensure Iceberg tables are declared correctly.
+
+    All DDL files must specify the Iceberg engine and fact tables must be
+    partitioned by ``event_date``.
+    """
+    ddl = sql_file.read_text().lower()
+    assert "using iceberg" in ddl, "DDL must specify USING iceberg"
+
+    if sql_file.name.startswith("fact_"):
+        assert "event_date" in ddl, "Fact tables require event_date column"
+        assert (
+            "partitioned by (event_date)" in ddl
+        ), "Fact tables must be partitioned by event_date"


### PR DESCRIPTION
## Summary
- add regression test to confirm Iceberg table DDLs declare the Iceberg engine and fact table partitioning
- mark TODO entry for Iceberg schema compliance test as complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f7d6e17548330b2697fa47fa0e3ab