### PR TITLE
test: ensure base generator determinism

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
 ## 📦 Ingestion Layer (Mock Producers)
 
 * [x] Implement base generator class with reproducible seeded randomness
-* [ ] For each warehouse (`north`, `south`, `east`, `west`):
+* [x] For each warehouse (`north`, `south`, `east`, `west`):
 
   * Orders generators:
     * [x] `produce_orders_north.py`
@@ -49,7 +49,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
 
 ## 🗂️ Data Modeling
 
-* [ ] Create Iceberg-compatible schemas for all `fact_` and `dim_` tables (match `AGENTS.md`)
+* [x] Create Iceberg-compatible schemas for all `fact_` and `dim_` tables (match `AGENTS.md`)
   * [x] `fact_orders`
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
@@ -66,7 +66,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] `dim_date`
   * [x] `dim_error_code`
 * [x] Partitioning strategy: use `event_date` for all `fact_` tables
-* [ ] Create Iceberg DDLs for DuckDB queries
+* [x] Create Iceberg DDLs for DuckDB queries
   * [x] `fact_orders`
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
@@ -176,7 +176,7 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
     * [x] Data generator schema match
     * [x] DAG syntax and dry-run
     * [x] Iceberg schema compliance
-  * [ ] Add logging to all generator and DAG processes
+  * [x] Add logging to all generator and DAG processes
     * [x] Introduce shared logger utility for producers
     * [x] Apply logging to order event producers and stg_orders DAG
     * [x] Apply logging to return event producers and stg_returns DAG

--- a/tests/test_base_generator.py
+++ b/tests/test_base_generator.py
@@ -1,0 +1,23 @@
+def _generate_sequences():
+    import importlib.util
+    from pathlib import Path
+
+    BASE_GENERATOR_PATH = (
+        Path(__file__).resolve().parents[1] / "ingestion" / "producers" / "base_generator.py"
+    )
+    spec = importlib.util.spec_from_file_location("base_generator", BASE_GENERATOR_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    BaseGenerator = module.BaseGenerator
+    gen = BaseGenerator("test_seed")
+    seq = [gen.randint(1, 100) for _ in range(5)]
+    choices = [gen.choice(["a", "b", "c"]) for _ in range(5)]
+    return seq, choices
+
+
+def test_seeded_randomness_is_reproducible():
+    seq1, choices1 = _generate_sequences()
+    seq2, choices2 = _generate_sequences()
+    assert seq1 == seq2
+    assert choices1 == choices2


### PR DESCRIPTION
## Summary
- mark warehouse producers, schema definitions, and logging tasks as complete
- add regression test verifying BaseGenerator's seeded randomness

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7f9308588330baf4686a326f6eff