### PR TITLE
feat: add dbt models for ml insights

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -82,14 +82,18 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
   * [x] `dim_employee`
   * [x] `dim_date`
   * [x] `dim_error_code`
-* [ ] Create YAML specs for dbt models
+* [x] Create YAML specs for dbt models
   * [x] `fact_returns`
   * [x] `fact_inventory_movements`
   * [x] `fact_dispatch_logs`
   * [x] `fact_order_errors`
+  * [x] `fact_forecast_demand`
+  * [x] `fact_stockout_risks`
   * [x] `stg_returns`
   * [x] `stg_dispatch_logs`
   * [x] `stg_inventory_movements`
+  * [x] `stg_forecast_demand`
+  * [x] `stg_stockout_risks`
 
 ---
 

--- a/models/dbt/dbt_project.yml
+++ b/models/dbt/dbt_project.yml
@@ -4,5 +4,5 @@ config-version: 2
 
 profile: 'mesh_warehouse'
 
-model-paths: ['dispatch_logs', 'inventory', 'orders', 'returns', 'order_errors']
+model-paths: ['dispatch_logs', 'inventory', 'orders', 'returns', 'order_errors', 'ml_insights']
 

--- a/models/dbt/ml_insights/docs.md
+++ b/models/dbt/ml_insights/docs.md
@@ -1,0 +1,15 @@
+{% docs stg_forecast_demand %}
+The `stg_forecast_demand` model normalizes raw demand forecast events and derives the `event_date` partition column.
+{% enddocs %}
+
+{% docs fact_forecast_demand %}
+Stores demand forecast outputs per product and region for downstream analytics.
+{% enddocs %}
+
+{% docs stg_stockout_risks %}
+The `stg_stockout_risks` model prepares stockout risk prediction events and computes the `event_date` partition column.
+{% enddocs %}
+
+{% docs fact_stockout_risks %}
+Captures ML-predicted stockout risk scores with associated confidence levels.
+{% enddocs %}

--- a/models/dbt/ml_insights/fact_forecast_demand.sql
+++ b/models/dbt/ml_insights/fact_forecast_demand.sql
@@ -1,0 +1,15 @@
+{{ config(materialized='incremental', unique_key='event_id') }}
+
+select
+    event_id,
+    event_ts,
+    event_type,
+    product_id,
+    region,
+    forecast_ts,
+    forecast_qty,
+    event_date
+from {{ ref('stg_forecast_demand') }}
+{% if is_incremental() %}
+where forecast_ts > (select max(forecast_ts) from {{ this }})
+{% endif %}

--- a/models/dbt/ml_insights/fact_stockout_risks.sql
+++ b/models/dbt/ml_insights/fact_stockout_risks.sql
@@ -1,0 +1,15 @@
+{{ config(materialized='incremental', unique_key='event_id') }}
+
+select
+    event_id,
+    event_ts,
+    event_type,
+    product_id,
+    risk_score,
+    predicted_date,
+    confidence,
+    event_date
+from {{ ref('stg_stockout_risks') }}
+{% if is_incremental() %}
+where event_ts > (select max(event_ts) from {{ this }})
+{% endif %}

--- a/models/dbt/ml_insights/schema.yml
+++ b/models/dbt/ml_insights/schema.yml
@@ -1,0 +1,83 @@
+version: 2
+
+sources:
+  - name: ml_insights
+    tables:
+      - name: raw_demand_forecast
+        description: "Raw demand forecast events produced by ML workflows."
+      - name: raw_stockout_risk
+        description: "Raw stockout risk events produced by ML workflows."
+
+models:
+  - name: stg_forecast_demand
+    description: "{{ doc('stg_forecast_demand') }}"
+    columns:
+      - name: event_id
+        description: "Unique event identifier"
+        tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: "Product identifier"
+      - name: region
+        description: "Region of forecast"
+      - name: forecast_ts
+        description: "Timestamp for which the forecast applies"
+      - name: forecast_qty
+        description: "Predicted quantity"
+      - name: event_date
+        description: "Partition column derived from forecast_ts"
+  - name: fact_forecast_demand
+    description: "{{ doc('fact_forecast_demand') }}"
+    columns:
+      - name: event_id
+        description: "Unique event identifier"
+        tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: "Product identifier"
+      - name: region
+        description: "Region of forecast"
+      - name: forecast_ts
+        description: "Timestamp for which the forecast applies"
+      - name: forecast_qty
+        description: "Predicted quantity"
+      - name: event_date
+        description: "Partition column derived from forecast_ts"
+  - name: stg_stockout_risks
+    description: "{{ doc('stg_stockout_risks') }}"
+    columns:
+      - name: event_id
+        description: "Unique event identifier"
+        tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: "Product identifier"
+      - name: risk_score
+        description: "Predicted risk score"
+      - name: predicted_date
+        description: "Date of predicted stockout"
+      - name: confidence
+        description: "Prediction confidence"
+      - name: event_date
+        description: "Partition column derived from event_ts"
+  - name: fact_stockout_risks
+    description: "{{ doc('fact_stockout_risks') }}"
+    columns:
+      - name: event_id
+        description: "Unique event identifier"
+        tests:
+          - not_null
+          - unique
+      - name: product_id
+        description: "Product identifier"
+      - name: risk_score
+        description: "Predicted risk score"
+      - name: predicted_date
+        description: "Date of predicted stockout"
+      - name: confidence
+        description: "Prediction confidence"
+      - name: event_date
+        description: "Partition column derived from event_ts"

--- a/models/dbt/ml_insights/stg_forecast_demand.sql
+++ b/models/dbt/ml_insights/stg_forecast_demand.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='view') }}
+
+with source as (
+    select * from {{ source('ml_insights', 'raw_demand_forecast') }}
+)
+
+select
+    event_id,
+    event_ts,
+    event_type,
+    product_id,
+    region,
+    forecast_ts,
+    forecast_qty,
+    cast(forecast_ts as date) as event_date
+from source

--- a/models/dbt/ml_insights/stg_stockout_risks.sql
+++ b/models/dbt/ml_insights/stg_stockout_risks.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='view') }}
+
+with source as (
+    select * from {{ source('ml_insights', 'raw_stockout_risk') }}
+)
+
+select
+    event_id,
+    event_ts,
+    event_type,
+    product_id,
+    risk_score,
+    predicted_date,
+    confidence,
+    cast(event_ts as date) as event_date
+from source


### PR DESCRIPTION
## Summary
- add ml_insights dbt models for demand forecasts and stockout risks
- wire up new models in dbt_project and mark TODOs complete

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890536eef0083308932a2b408bf7636