### PR TITLE
Add ML staging and fact DAGs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -116,17 +116,21 @@ This document tracks development milestones for the **Mesh-terious Warehouse** p
     * [x] `ingest_dispatch_logs_east.py` → from RabbitMQ to Iceberg
     * [x] `ingest_dispatch_logs_west.py` → from RabbitMQ to Iceberg
     * [x] `ingest_inventory_<region>.py` → from RabbitMQ to Iceberg
-  * [ ] `stg_<entity>.py` → transform raw to staging (via dbt)
+  * [x] `stg_<entity>.py` → transform raw to staging (via dbt)
       * [x] `stg_orders.py`
       * [x] `stg_returns.py`
       * [x] `stg_dispatch_logs.py`
       * [x] `stg_inventory_movements.py`
-  * [ ] `fact_<entity>.py` → load final fact tables
+      * [x] `stg_forecast_demand.py`
+      * [x] `stg_stockout_risks.py`
+  * [x] `fact_<entity>.py` → load final fact tables
     * [x] `fact_orders.py`
     * [x] `fact_returns.py`
     * [x] `fact_inventory_movements.py`
     * [x] `fact_dispatch_logs.py`
     * [x] `fact_order_errors.py`
+    * [x] `fact_forecast_demand.py`
+    * [x] `fact_stockout_risks.py`
   * [x] ML DAGs:
 
   * [x] `forecast_demand.py`

--- a/dags/ml_dags/fact_forecast_demand.py
+++ b/dags/ml_dags/fact_forecast_demand.py
@@ -1,0 +1,26 @@
+"""Airflow DAG to run the fact_forecast_demand dbt model."""
+from __future__ import annotations
+
+from pathlib import Path
+import logging
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+logger = logging.getLogger(__name__)
+
+DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
+
+with DAG(
+    dag_id="fact_forecast_demand",
+    schedule_interval="@daily",
+    start_date=days_ago(1),
+    catchup=False,
+    tags=["ml", "fact"],
+) as dag:
+    logger.info("Configuring fact_forecast_demand DAG")
+    BashOperator(
+        task_id="dbt_run_fact_forecast_demand",
+        bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models fact_forecast_demand",
+    )

--- a/dags/ml_dags/fact_stockout_risks.py
+++ b/dags/ml_dags/fact_stockout_risks.py
@@ -1,0 +1,26 @@
+"""Airflow DAG to run the fact_stockout_risks dbt model."""
+from __future__ import annotations
+
+from pathlib import Path
+import logging
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+logger = logging.getLogger(__name__)
+
+DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
+
+with DAG(
+    dag_id="fact_stockout_risks",
+    schedule_interval="@daily",
+    start_date=days_ago(1),
+    catchup=False,
+    tags=["ml", "fact"],
+) as dag:
+    logger.info("Configuring fact_stockout_risks DAG")
+    BashOperator(
+        task_id="dbt_run_fact_stockout_risks",
+        bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models fact_stockout_risks",
+    )

--- a/dags/ml_dags/stg_forecast_demand.py
+++ b/dags/ml_dags/stg_forecast_demand.py
@@ -1,0 +1,26 @@
+"""Airflow DAG to run the stg_forecast_demand dbt model."""
+from __future__ import annotations
+
+from pathlib import Path
+import logging
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+logger = logging.getLogger(__name__)
+
+DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
+
+with DAG(
+    dag_id="stg_forecast_demand",
+    schedule_interval="@daily",
+    start_date=days_ago(1),
+    catchup=False,
+    tags=["ml", "staging"],
+) as dag:
+    logger.info("Configuring stg_forecast_demand DAG")
+    BashOperator(
+        task_id="dbt_run_stg_forecast_demand",
+        bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models stg_forecast_demand",
+    )

--- a/dags/ml_dags/stg_stockout_risks.py
+++ b/dags/ml_dags/stg_stockout_risks.py
@@ -1,0 +1,26 @@
+"""Airflow DAG to run the stg_stockout_risks dbt model."""
+from __future__ import annotations
+
+from pathlib import Path
+import logging
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils.dates import days_ago
+
+logger = logging.getLogger(__name__)
+
+DBT_PROJECT_DIR = Path(__file__).resolve().parents[2] / "models" / "dbt"
+
+with DAG(
+    dag_id="stg_stockout_risks",
+    schedule_interval="@daily",
+    start_date=days_ago(1),
+    catchup=False,
+    tags=["ml", "staging"],
+) as dag:
+    logger.info("Configuring stg_stockout_risks DAG")
+    BashOperator(
+        task_id="dbt_run_stg_stockout_risks",
+        bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --models stg_stockout_risks",
+    )


### PR DESCRIPTION
## Summary
- add Airflow DAGs for dbt models stg_forecast_demand and stg_stockout_risks
- add Airflow DAGs for dbt models fact_forecast_demand and fact_stockout_risks
- mark associated tasks complete in TODO.md

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689054a3ad588330ac28020e984c21a5