### PR TITLE
chore: remove duckdb container and share db file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   rabbitmq:
     image: rabbitmq:3-management
@@ -41,6 +39,7 @@ services:
     volumes:
       - ./dags:/opt/airflow/dags
       - airflow_data:/opt/airflow
+      - duckdb_data:/data
     ports:
       - "8080:8080"
     depends_on:
@@ -52,21 +51,15 @@ services:
   openmetadata:
     image: openmetadata/server:1.2.2
     container_name: openmetadata
+    env_file: .env
     ports:
       - "8585:8585"
     environment:
       OPENMETADATA_SERVER_CONFIG: /openmetadata/config/docker.yaml
-    depends_on:
-      - minio
-    networks:
-      - mesh
-
-  duckdb:
-    image: ghcr.io/duckdb/duckdb:latest
-    container_name: duckdb
-    command: ["tail", "-f", "/dev/null"]
     volumes:
       - duckdb_data:/data
+    depends_on:
+      - minio
     networks:
       - mesh
 
@@ -82,8 +75,6 @@ services:
       - duckdb_data:/data
     ports:
       - "8088:8088"
-    depends_on:
-      - duckdb
     networks:
       - mesh
 


### PR DESCRIPTION
## Summary
- remove dedicated DuckDB service from docker compose
- mount shared DuckDB volume into Airflow, OpenMetadata, and Superset

## Testing
- `docker-compose config` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68905e53443c83309333fd84461c594c