### PR TITLE
fix: correct Airflow and OpenMetadata entries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
   airflow:
     image: apache/airflow:2.8.1
     container_name: airflow
+    command: standalone
     env_file: .env
     environment:
       AIRFLOW__CORE__EXECUTOR: ${AIRFLOW__CORE__EXECUTOR}
@@ -54,12 +55,8 @@ services:
     env_file: .env
     ports:
       - "8585:8585"
-    environment:
-      OPENMETADATA_SERVER_CONFIG: /openmetadata/config/docker.yaml
     volumes:
       - duckdb_data:/data
-    depends_on:
-      - minio
     networks:
       - mesh
 


### PR DESCRIPTION
## Summary
- ensure Airflow container starts with standalone command
- drop invalid OpenMetadata config reference for default startup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68906b9bf3148330b86d5dca38f60fe5