### PR TITLE
Use DuckDB with Iceberg tables on MinIO S3

### DIFF
--- a/dags/models/dbt/profiles.yml
+++ b/dags/models/dbt/profiles.yml
@@ -2,5 +2,15 @@ mesh_warehouse:
   outputs:
     dev:
       type: duckdb
-      path: /data/warehouse.duckdb
+      path: ":memory:"
+      extensions:
+        - httpfs
+        - iceberg
+      settings:
+        s3_endpoint: "{{ env_var('MINIO_ENDPOINT') }}"
+        s3_access_key_id: "{{ env_var('MINIO_ROOT_USER') }}"
+        s3_secret_access_key: "{{ env_var('MINIO_ROOT_PASSWORD') }}"
+        s3_region: "us-east-1"
+        s3_url_style: "path"
+        s3_use_ssl: "false"
   target: dev

--- a/ml/forecasting.py
+++ b/ml/forecasting.py
@@ -3,8 +3,36 @@ from __future__ import annotations
 
 from datetime import date
 from typing import Iterable, List, Dict
+import os
 
 import duckdb
+
+
+DEFAULT_DUCKDB_PATH = os.getenv(
+    "DUCKDB_PATH", "s3://warehouse/fact_stockout_risks"
+)
+
+
+def _connect(db_path: str) -> duckdb.DuckDBPyConnection:
+    """Return a DuckDB connection using MinIO settings when required."""
+    if db_path.startswith("s3://"):
+        con = duckdb.connect(
+            ":memory:",
+            config={
+                "s3_endpoint": os.getenv("MINIO_ENDPOINT", "http://minio:9000"),
+                "s3_access_key_id": os.getenv(
+                    "MINIO_ROOT_USER", "minioadmin"
+                ),
+                "s3_secret_access_key": os.getenv(
+                    "MINIO_ROOT_PASSWORD", "minioadmin"
+                ),
+                "s3_url_style": "path",
+                "s3_use_ssl": "false",
+            },
+        )
+        con.execute("INSTALL httpfs; LOAD httpfs; INSTALL iceberg; LOAD iceberg")
+        return con
+    return duckdb.connect(db_path)
 
 
 def moving_average(history: Iterable[float]) -> float:
@@ -20,43 +48,70 @@ def moving_average(history: Iterable[float]) -> float:
     return sum(values) / len(values)
 
 
-def write_stockout_risk(predictions: List[Dict], db_path: str) -> int:
-    """Write predictions to a DuckDB table and return inserted row count."""
+def write_stockout_risk(
+    predictions: List[Dict], db_path: str = DEFAULT_DUCKDB_PATH
+) -> int:
+    """Write predictions to a DuckDB or Iceberg table and return inserted row count."""
 
-    con = duckdb.connect(db_path)
-    con.execute(
-        """
-        CREATE TABLE IF NOT EXISTS fact_stockout_risks (
-            product_id INTEGER,
-            predicted_date DATE,
-            risk_score DOUBLE,
-            confidence DOUBLE
+    con = _connect(db_path)
+    rows = [
+        (
+            p["product_id"],
+            p["predicted_date"],
+            p["risk_score"],
+            p["confidence"],
         )
-        """
-    )
-    con.executemany(
-        "INSERT INTO fact_stockout_risks VALUES (?, ?, ?, ?)",
-        [
-            (
-                p["product_id"],
-                p["predicted_date"],
-                p["risk_score"],
-                p["confidence"],
+        for p in predictions
+    ]
+
+    if rows:
+        if db_path.startswith("s3://"):
+            con.execute(
+                """
+                CREATE TEMPORARY TABLE tmp_stockout (
+                    product_id INTEGER,
+                    predicted_date DATE,
+                    risk_score DOUBLE,
+                    confidence DOUBLE
+                )
+                """
             )
-            for p in predictions
-        ],
-    )
+            con.executemany(
+                "INSERT INTO tmp_stockout VALUES (?, ?, ?, ?)", rows
+            )
+            con.execute(
+                f"COPY tmp_stockout TO '{db_path}' (FORMAT ICEBERG)"
+            )
+        else:
+            con.execute(
+                """
+                CREATE TABLE IF NOT EXISTS fact_stockout_risks (
+                    product_id INTEGER,
+                    predicted_date DATE,
+                    risk_score DOUBLE,
+                    confidence DOUBLE
+                )
+                """
+            )
+            con.executemany(
+                "INSERT INTO fact_stockout_risks VALUES (?, ?, ?, ?)", rows
+            )
     con.close()
-    return len(predictions)
+    return len(rows)
 
 
-def validate_stockout_risk(db_path: str) -> int:
-    """Validate stored predictions are within bounds and return row count."""
+def validate_stockout_risk(db_path: str = DEFAULT_DUCKDB_PATH) -> int:
+    """Validate stored predictions (DuckDB or Iceberg) are within bounds and return row count."""
 
-    con = duckdb.connect(db_path)
-    rows = con.execute(
-        "SELECT product_id, predicted_date, risk_score, confidence FROM fact_stockout_risks"
-    ).fetchall()
+    con = _connect(db_path)
+    if db_path.startswith("s3://"):
+        rows = con.execute(
+            f"SELECT product_id, predicted_date, risk_score, confidence FROM read_iceberg('{db_path}')"
+        ).fetchall()
+    else:
+        rows = con.execute(
+            "SELECT product_id, predicted_date, risk_score, confidence FROM fact_stockout_risks"
+        ).fetchall()
     con.close()
     for _, _, risk_score, confidence in rows:
         if not (0 <= risk_score <= 1) or not (0 <= confidence <= 1):


### PR DESCRIPTION
## Summary
- Load DuckDB's httpfs and iceberg extensions when a MinIO S3 path is provided and copy prediction data into Iceberg tables
- Query Iceberg tables with `read_iceberg` and configure dbt to operate against an in-memory DuckDB backed by MinIO S3

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689849ee2b8883309624eba8d5a22bc2