### PR TITLE
Align orders ingestion with dbt source

### DIFF
--- a/dags/models/dbt/orders/schema.yml
+++ b/dags/models/dbt/orders/schema.yml
@@ -5,6 +5,9 @@ sources:
     tables:
       - name: raw_orders
         description: "Raw orders ingested from RabbitMQ."
+        external:
+          location: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}/orders/raw_orders"
+          format: iceberg
 
 models:
   - name: stg_orders

--- a/dags/orders_dags/ingest_orders_east.py
+++ b/dags/orders_dags/ingest_orders_east.py
@@ -44,10 +44,10 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_east",
         queue_name="orders_east",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 

--- a/dags/orders_dags/ingest_orders_north.py
+++ b/dags/orders_dags/ingest_orders_north.py
@@ -44,11 +44,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_north",
         queue_name="orders_north",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_north DAG")
+

--- a/dags/orders_dags/ingest_orders_south.py
+++ b/dags/orders_dags/ingest_orders_south.py
@@ -44,11 +44,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_south",
         queue_name="orders_south",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_south DAG")
+

--- a/dags/orders_dags/ingest_orders_west.py
+++ b/dags/orders_dags/ingest_orders_west.py
@@ -44,11 +44,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_west",
         queue_name="orders_west",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_west DAG")
+


### PR DESCRIPTION
## Summary
- direct order ingestion to `orders.raw_orders` instead of `warehouse.fact_orders`
- configure dbt `raw_orders` source to read from Iceberg location

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f35056df883308ce4eb50408000ce