### PR TITLE
Align orders ingestion with dbt source

### DIFF
--- a/dags/models/dbt/orders/schema.yml
+++ b/dags/models/dbt/orders/schema.yml
@@ -5,6 +5,9 @@ sources:
     tables:
       - name: raw_orders
         description: "Raw orders ingested from RabbitMQ."
+        external:
+          location: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}/orders/raw_orders"
+          format: iceberg
 
 models:
   - name: stg_orders

--- a/dags/models/dbt/profiles.yml
+++ b/dags/models/dbt/profiles.yml
@@ -13,4 +13,17 @@ mesh_warehouse:
         s3_region: "us-east-1"
         s3_url_style: "path"
         s3_use_ssl: "false"
+      plugins:
+        - module: iceberg
+          config:
+            catalog: "{{ env_var('ICEBERG_CATALOG', 'minio') }}"
+            uri: "{{ env_var('ICEBERG_REST_URI', 'http://iceberg-rest:8181') }}"
+            warehouse: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}"
+            py-io-impl: "pyiceberg.io.pyarrow.PyArrowFileIO"
+            s3.endpoint: "{{ env_var('MINIO_ENDPOINT', 'http://minio:9000') }}"
+            s3.access-key-id: "{{ env_var('MINIO_ROOT_USER', 'minioadmin') }}"
+            s3.secret-access-key: "{{ env_var('MINIO_ROOT_PASSWORD', 'minioadmin') }}"
+            s3.path-style-access: "true"
+            s3.region: "us-east-1"
+            s3.signing-region: "us-east-1"
   target: dev

--- a/dags/orders_dags/ingest_orders_east.py
+++ b/dags/orders_dags/ingest_orders_east.py
@@ -44,10 +44,10 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_east",
         queue_name="orders_east",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 

--- a/dags/orders_dags/ingest_orders_north.py
+++ b/dags/orders_dags/ingest_orders_north.py
@@ -44,11 +44,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_north",
         queue_name="orders_north",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_north DAG")
+

--- a/dags/orders_dags/ingest_orders_south.py
+++ b/dags/orders_dags/ingest_orders_south.py
@@ -44,11 +44,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_south",
         queue_name="orders_south",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_south DAG")
+

--- a/dags/orders_dags/ingest_orders_west.py
+++ b/dags/orders_dags/ingest_orders_west.py
@@ -44,11 +44,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_west",
         queue_name="orders_west",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_west DAG")
+


### PR DESCRIPTION
## Summary
- direct order ingestion to `orders.raw_orders` instead of `warehouse.fact_orders`
- configure dbt `raw_orders` source to read from Iceberg location
- load Iceberg catalog in dbt profile so DuckDB resolves external tables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f35056df883308ce4eb50408000ce