### PR TITLE
Align orders ingestion with dbt source

### DIFF
--- a/dags/models/dbt/orders/schema.yml
+++ b/dags/models/dbt/orders/schema.yml
@@ -2,9 +2,14 @@ version: 2
 
 sources:
   - name: orders
+    database: "{{ env_var('ICEBERG_CATALOG', 'minio') }}"
+    schema: orders
     tables:
       - name: raw_orders
         description: "Raw orders ingested from RabbitMQ."
+        external:
+          location: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}/orders/raw_orders"
+          format: iceberg
 
 models:
   - name: stg_orders

--- a/dags/models/dbt/profiles.yml
+++ b/dags/models/dbt/profiles.yml
@@ -7,10 +7,22 @@ mesh_warehouse:
         - httpfs
         - iceberg
       settings:
-        s3_endpoint: "{{ env_var('MINIO_ENDPOINT') }}"
-        s3_access_key_id: "{{ env_var('MINIO_ROOT_USER') }}"
-        s3_secret_access_key: "{{ env_var('MINIO_ROOT_PASSWORD') }}"
+        s3_endpoint: "{{ env_var('MINIO_ENDPOINT', 'http://minio:9000') }}"
+        s3_access_key_id: "{{ env_var('MINIO_ROOT_USER', 'minioadmin') }}"
+        s3_secret_access_key: "{{ env_var('MINIO_ROOT_PASSWORD', 'minioadmin') }}"
         s3_region: "us-east-1"
         s3_url_style: "path"
         s3_use_ssl: "false"
+      attach:
+        - path: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}"
+          type: iceberg
+          alias: "{{ env_var('ICEBERG_CATALOG', 'minio') }}"
+          options:
+            S3_ENDPOINT: "{{ env_var('MINIO_ENDPOINT', 'http://minio:9000') }}"
+            S3_ACCESS_KEY_ID: "{{ env_var('MINIO_ROOT_USER', 'minioadmin') }}"
+            S3_SECRET_ACCESS_KEY: "{{ env_var('MINIO_ROOT_PASSWORD', 'minioadmin') }}"
+            S3_URL_STYLE: "path"
+            S3_USE_SSL: "false"
+            S3_REGION: "us-east-1"
+            S3_SIGNING_REGION: "us-east-1"
   target: dev

--- a/dags/orders_dags/ingest_orders_east.py
+++ b/dags/orders_dags/ingest_orders_east.py
@@ -44,10 +44,10 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_east",
         queue_name="orders_east",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 

--- a/dags/orders_dags/ingest_orders_north.py
+++ b/dags/orders_dags/ingest_orders_north.py
@@ -44,11 +44,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_north",
         queue_name="orders_north",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_north DAG")
+

--- a/dags/orders_dags/ingest_orders_south.py
+++ b/dags/orders_dags/ingest_orders_south.py
@@ -44,11 +44,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_south",
         queue_name="orders_south",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_south DAG")
+

--- a/dags/orders_dags/ingest_orders_west.py
+++ b/dags/orders_dags/ingest_orders_west.py
@@ -44,11 +44,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_west",
         queue_name="orders_west",
-        table_fqn="warehouse.fact_orders",
+        table_fqn="orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_west DAG")
+


### PR DESCRIPTION
## Summary
- attach MinIO Iceberg warehouse to DuckDB in dbt profile
- provide default MinIO settings for local runs

## Testing
- `pytest`
- `dbt run --select stg_orders` *(fails: Could not download httpfs extension)*

------
https://chatgpt.com/codex/tasks/task_e_689f35056df883308ce4eb50408000ce