### PR TITLE
Align orders ingestion with dbt source

### DIFF
--- a/dags/models/dbt/orders/schema.yml
+++ b/dags/models/dbt/orders/schema.yml
@@ -2,9 +2,14 @@ version: 2
 
 sources:
   - name: orders
+    database: "{{ env_var('ICEBERG_CATALOG', 'minio') }}"
+    schema: orders
     tables:
       - name: raw_orders
         description: "Raw orders ingested from RabbitMQ."
+        external:
+          location: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}/orders/raw_orders"
+          format: iceberg
 
 models:
   - name: stg_orders

--- a/dags/models/dbt/profiles.yml
+++ b/dags/models/dbt/profiles.yml
@@ -6,11 +6,18 @@ mesh_warehouse:
       extensions:
         - httpfs
         - iceberg
-      settings:
-        s3_endpoint: "{{ env_var('MINIO_ENDPOINT') }}"
-        s3_access_key_id: "{{ env_var('MINIO_ROOT_USER') }}"
-        s3_secret_access_key: "{{ env_var('MINIO_ROOT_PASSWORD') }}"
-        s3_region: "us-east-1"
-        s3_url_style: "path"
-        s3_use_ssl: "false"
+      secrets:
+        - name: minio
+          type: s3
+          key_id: "{{ env_var('MINIO_ROOT_USER', 'minioadmin') }}"
+          secret: "{{ env_var('MINIO_ROOT_PASSWORD', 'minioadmin') }}"
+          endpoint: "{{ env_var('MINIO_ENDPOINT', 'http://minio:9000') }}"
+          region: "us-east-1"
+          url_style: "path"
+          use_ssl: "false"
+      attach:
+        - path: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}"
+          type: iceberg
+          alias: "{{ env_var('ICEBERG_CATALOG', 'minio') }}"
+          secret: minio
   target: dev

--- a/dags/orders_dags/ingest_orders_east.py
+++ b/dags/orders_dags/ingest_orders_east.py
@@ -1,6 +1,7 @@
 """Ingest order events from RabbitMQ to Iceberg for east region."""
 from datetime import datetime
 import logging
+import os
 
 from pydantic import BaseModel
 
@@ -44,10 +45,10 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_east",
         queue_name="orders_east",
-        table_fqn="warehouse.fact_orders",
+        table_fqn=f"{os.getenv('ICEBERG_CATALOG', 'minio')}.orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 

--- a/dags/orders_dags/ingest_orders_north.py
+++ b/dags/orders_dags/ingest_orders_north.py
@@ -1,6 +1,7 @@
 """Ingest order events from RabbitMQ to Iceberg for north region."""
 from datetime import datetime
 import logging
+import os
 
 from pydantic import BaseModel
 
@@ -44,11 +45,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_north",
         queue_name="orders_north",
-        table_fqn="warehouse.fact_orders",
+        table_fqn=f"{os.getenv('ICEBERG_CATALOG', 'minio')}.orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_north DAG")
+

--- a/dags/orders_dags/ingest_orders_south.py
+++ b/dags/orders_dags/ingest_orders_south.py
@@ -1,6 +1,7 @@
 """Ingest order events from RabbitMQ to Iceberg for south region."""
 from datetime import datetime
 import logging
+import os
 
 from pydantic import BaseModel
 
@@ -44,11 +45,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_south",
         queue_name="orders_south",
-        table_fqn="warehouse.fact_orders",
+        table_fqn=f"{os.getenv('ICEBERG_CATALOG', 'minio')}.orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_south DAG")
+

--- a/dags/orders_dags/ingest_orders_west.py
+++ b/dags/orders_dags/ingest_orders_west.py
@@ -1,6 +1,7 @@
 """Ingest order events from RabbitMQ to Iceberg for west region."""
 from datetime import datetime
 import logging
+import os
 
 from pydantic import BaseModel
 
@@ -44,11 +45,12 @@ with DAG(
     build_ingest_operator(
         dag_id="ingest_orders_west",
         queue_name="orders_west",
-        table_fqn="warehouse.fact_orders",
+        table_fqn=f"{os.getenv('ICEBERG_CATALOG', 'minio')}.orders.raw_orders",
         event_model=OrderEvent,
         columns=COLUMNS,
-        table_description="Orders fact table",
+        table_description="Raw orders table",
         date_field="order_ts",
     )
 
 logger.info("Configured ingest_orders_west DAG")
+


### PR DESCRIPTION
## Summary
- attach MinIO Iceberg warehouse to DuckDB in dbt profile
- provide default MinIO settings for local runs
- hardcode orders dbt source to `minio` catalog
- define an S3 secret and reference it when attaching the MinIO catalog
- route orders ingestion DAGs to write raw events into the MinIO catalog

## Testing
- `pytest`
- `dbt run --select stg_orders --profiles-dir dags/models/dbt --project-dir dags/models/dbt` *(fails: Failed to download httpfs extension)*

------
https://chatgpt.com/codex/tasks/task_e_689f35056df883308ce4eb50408000ce