### PR TITLE
Configure dbt sources for Iceberg

### DIFF
--- a/dags/models/dbt/dispatch_logs/schema.yml
+++ b/dags/models/dbt/dispatch_logs/schema.yml
@@ -2,9 +2,16 @@ version: 2
 
 sources:
   - name: dispatch_logs
+    database: "{{ env_var('ICEBERG_CATALOG', 'minio') }}"
+    schema: dispatch_logs
     tables:
       - name: raw_dispatch_logs
         description: "Raw dispatch log events ingested from RabbitMQ."
+        external:
+          location: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}/dispatch_logs/raw_dispatch_logs"
+          format: iceberg
+          options:
+            allow_moved_paths: true
 
 models:
   - name: stg_dispatch_logs

--- a/dags/models/dbt/inventory/schema.yml
+++ b/dags/models/dbt/inventory/schema.yml
@@ -2,9 +2,16 @@ version: 2
 
 sources:
   - name: inventory
+    database: "{{ env_var('ICEBERG_CATALOG', 'minio') }}"
+    schema: inventory
     tables:
       - name: raw_inventory_movements
         description: "Raw inventory movements ingested from RabbitMQ."
+        external:
+          location: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}/inventory/raw_inventory_movements"
+          format: iceberg
+          options:
+            allow_moved_paths: true
 
 models:
   - name: stg_inventory_movements

--- a/dags/models/dbt/ml_insights/schema.yml
+++ b/dags/models/dbt/ml_insights/schema.yml
@@ -2,11 +2,23 @@ version: 2
 
 sources:
   - name: ml_insights
+    database: "{{ env_var('ICEBERG_CATALOG', 'minio') }}"
+    schema: ml_insights
     tables:
       - name: raw_demand_forecast
         description: "Raw demand forecast events produced by ML workflows."
+        external:
+          location: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}/ml_insights/raw_demand_forecast"
+          format: iceberg
+          options:
+            allow_moved_paths: true
       - name: raw_stockout_risk
         description: "Raw stockout risk events produced by ML workflows."
+        external:
+          location: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}/ml_insights/raw_stockout_risk"
+          format: iceberg
+          options:
+            allow_moved_paths: true
 
 models:
   - name: stg_forecast_demand

--- a/dags/models/dbt/order_errors/schema.yml
+++ b/dags/models/dbt/order_errors/schema.yml
@@ -2,9 +2,16 @@ version: 2
 
 sources:
   - name: order_errors
+    database: "{{ env_var('ICEBERG_CATALOG', 'minio') }}"
+    schema: order_errors
     tables:
       - name: raw_order_errors
         description: "Raw order error events ingested from RabbitMQ."
+        external:
+          location: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}/order_errors/raw_order_errors"
+          format: iceberg
+          options:
+            allow_moved_paths: true
 
 models:
   - name: fact_order_errors

--- a/dags/models/dbt/orders/schema.yml
+++ b/dags/models/dbt/orders/schema.yml
@@ -10,6 +10,8 @@ sources:
         external:
           location: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}/orders/raw_orders"
           format: iceberg
+          options:
+            allow_moved_paths: true
 
 models:
   - name: stg_orders

--- a/dags/models/dbt/profiles.yml
+++ b/dags/models/dbt/profiles.yml
@@ -10,7 +10,7 @@ mesh_warehouse:
         s3_region: "{{ env_var('MINIO_REGION', 'us-east-1') }}"
         s3_use_ssl: false
         s3_url_style: path
-        s3_endpoint: "{{ env_var('MINIO_ENDPOINT', 'http://minio:9000')"
+        s3_endpoint: "{{ env_var('MINIO_ENDPOINT', 'minio:9000') }}"
         s3_access_key_id: "{{ env_var('MINIO_ROOT_USER', 'minioadmin') }}"
         s3_secret_access_key: "{{ env_var('MINIO_ROOT_PASSWORD', 'minioadmin') }}"
         unsafe_enable_version_guessing: true

--- a/dags/models/dbt/returns/schema.yml
+++ b/dags/models/dbt/returns/schema.yml
@@ -2,9 +2,16 @@ version: 2
 
 sources:
   - name: returns
+    database: "{{ env_var('ICEBERG_CATALOG', 'minio') }}"
+    schema: returns
     tables:
       - name: raw_returns
         description: "Raw returns ingested from RabbitMQ."
+        external:
+          location: "{{ env_var('ICEBERG_WAREHOUSE', 's3://warehouse') }}/returns/raw_returns"
+          format: iceberg
+          options:
+            allow_moved_paths: true
 
 models:
   - name: stg_returns


### PR DESCRIPTION
## Summary
- fix MinIO endpoint in dbt profile for DuckDB Iceberg access
- add Iceberg external sources with allow_moved_paths option for all domains

## Testing
- `cd dags/models/dbt && dbt parse`

------
https://chatgpt.com/codex/tasks/task_e_689f57414ff8833086b56ba93f97275c