### PR TITLE
Fix fact_orders DAG to build dependencies and add SLA

### DIFF
--- a/dags/orders_dags/fact_orders.py
+++ b/dags/orders_dags/fact_orders.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 
 from airflow import DAG
 from airflow.providers.standard.operators.bash import BashOperator
+from airflow.sensors.external_task import ExternalTaskSensor
 import datetime
 from airflow.utils import timezone
 
@@ -16,7 +17,8 @@ def days_ago(n):
 logger = logging.getLogger(__name__)
 
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[1] / "models" / "dbt"
-DEFAULT_ARGS = {"owner": "data-eng", "retries": 1}
+# Include an SLA for this DAG to ensure timely fact table builds
+DEFAULT_ARGS = {"owner": "data-eng", "retries": 1, "sla": timedelta(minutes=30)}
 
 with DAG(
     dag_id="fact_orders",
@@ -27,7 +29,21 @@ with DAG(
     default_args=DEFAULT_ARGS,
 ) as dag:
     logger.info("Configuring fact_orders DAG")
-    BashOperator(
-        task_id="dbt_run_fact_orders",
-        bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --select fact_orders",
+    wait_for_staging = ExternalTaskSensor(
+        task_id="wait_for_stg_orders",
+        external_dag_id="stg_orders",
+        poke_interval=60,
+        timeout=60 * 60,
     )
+
+    dbt_run_fact_orders = BashOperator(
+        task_id="dbt_run_fact_orders",
+        # Run the fact model along with any upstream dependencies
+        # so that staging models like ``stg_orders`` are built before the
+        # ``fact_orders`` model executes. Without the ``+`` selector dbt only
+        # runs the specified model, which resulted in failures when the
+        # required staging table was missing.
+        bash_command=f"cd {DBT_PROJECT_DIR} && dbt run --select +fact_orders",
+    )
+
+    wait_for_staging >> dbt_run_fact_orders

--- a/dags/orders_dags/stg_orders.py
+++ b/dags/orders_dags/stg_orders.py
@@ -16,7 +16,8 @@ def days_ago(n):
 logger = logging.getLogger(__name__)
 
 DBT_PROJECT_DIR = Path(__file__).resolve().parents[1] / "models" / "dbt"
-DEFAULT_ARGS = {"owner": "data-eng", "retries": 1}
+# Define an SLA to satisfy operational monitoring requirements
+DEFAULT_ARGS = {"owner": "data-eng", "retries": 1, "sla": timedelta(minutes=30)}
 
 with DAG(
     dag_id="stg_orders",


### PR DESCRIPTION
## Summary
- ensure `fact_orders` dbt runs include upstream staging models
- add SLA monitoring to orders staging and fact DAGs
- wait for `stg_orders` DAG completion before running fact model

## Testing
- `pip install duckdb`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2904e3f008330be89e991356afcc0